### PR TITLE
Factor get_verbosity into common space and convert printf to cout

### DIFF
--- a/Lib/include/STKFMM/STKFMM.hpp
+++ b/Lib/include/STKFMM/STKFMM.hpp
@@ -20,6 +20,10 @@
  *
  */
 namespace stkfmm {
+/**
+ * @brief get STKFMM_VERBOSE environment variable
+ */
+bool get_verbosity();
 
 /**
  * @brief a virtual interface for STKFMM cases

--- a/Lib/include/STKFMM/STKFMM_common.hpp
+++ b/Lib/include/STKFMM/STKFMM_common.hpp
@@ -16,7 +16,7 @@ namespace stkfmm {
  *
  * Set environment variable STKFMM_VERBOSE=1 to enable
  */
-extern bool verbose;
+extern const bool verbose;
 
 /**
  * @brief choose the periodic boundary condition

--- a/Lib/src/FMMData.cpp
+++ b/Lib/src/FMMData.cpp
@@ -126,7 +126,7 @@ void FMMData::setupTree(const std::vector<double> &srcSLCoord, const std::vector
     MPI_Comm_rank(comm, &rank);
 
     if (stkfmm::verbose)
-        printf("Rank %d, nSL %d, nDL %d, nTrg %d\n", rank, nSL, nDL, nTrg);
+        std::cout << "Rank " << rank << ", nSL " << nSL << ", nDL " << nDL << ", nTrg " << nTrg << std::endl;
 
     // space allocate
     treeDataPtr->src_value.Resize(nSL * kdimSL);
@@ -161,15 +161,15 @@ void FMMData::evaluateFMM(std::vector<double> &srcSLValue, std::vector<double> &
     MPI_Comm_rank(comm, &rank);
 
     if (nTrg * kdimTrg != trgValue.size()) {
-        printf("trg value size error from rank %d\n", rank);
+        std::cout << "trg value size error from rank " << rank << std::endl;
         exit(1);
     }
     if (nSrc * kdimSL != srcSLValue.size()) {
-        printf("src SL value size error from rank %d\n", rank);
+        std::cout << "src SL value size error from rank " << rank << std::endl;
         exit(1);
     }
     if (nSurf * kdimDL != srcDLValue.size()) {
-        printf("src DL value size error from rank %d\n", rank);
+        std::cout << "src DL value size error from rank " << rank << std::endl;
         exit(1);
     }
     scaleSrc(srcSLValue, srcDLValue, scale);

--- a/Lib/src/STKFMM.cpp
+++ b/Lib/src/STKFMM.cpp
@@ -4,6 +4,17 @@ extern pvfmm::PeriodicType pvfmm::periodicType;
 
 namespace stkfmm {
 
+bool get_verbosity() {
+    char *verbose_env;
+    verbose_env = getenv("STKFMM_VERBOSE");
+    if (verbose_env == nullptr || verbose_env[0] == '0')
+        return false;
+
+    return true;
+}
+
+const bool verbose = get_verbosity();
+
 const std::unordered_map<KERNEL, const pvfmm::Kernel<double> *> kernelMap = {
     {KERNEL::LapPGrad, &pvfmm::LaplaceLayerKernel<double>::PGrad()},
     {KERNEL::LapPGradGrad, &pvfmm::LaplaceLayerKernel<double>::PGradGrad()},

--- a/Lib/src/Stk3DFMM.cpp
+++ b/Lib/src/Stk3DFMM.cpp
@@ -3,17 +3,6 @@
 
 namespace stkfmm {
 
-bool get_verbosity() {
-    char *verbose_env;
-    verbose_env = getenv("STKFMM_VERBOSE");
-    if (verbose_env == nullptr || verbose_env[0] == '0')
-        return false;
-
-    return true;
-}
-
-bool verbose = get_verbosity();
-
 Stk3DFMM::Stk3DFMM(int multOrder_, int maxPts_, PAXIS pbc_, unsigned int kernelComb_)
     : STKFMM(multOrder_, maxPts_, pbc_, kernelComb_) {
     using namespace impl;
@@ -29,7 +18,7 @@ Stk3DFMM::Stk3DFMM(int multOrder_, int maxPts_, PAXIS pbc_, unsigned int kernelC
     }
 
     if (poolFMM.empty()) {
-        printf("Error: no kernel activated\n");
+        std::cout << "Error: no kernel activated\n";
     }
 }
 
@@ -50,7 +39,7 @@ void Stk3DFMM::setPoints(const int nSL, const double *srcSLCoordPtr, const int n
             fmm.second->deleteTree();
         }
         if (stkfmm::verbose && rank == 0)
-            printf("ALL FMM Tree Cleared\n");
+            std::cout << "ALL FMM Tree Cleared\n";
     }
 
     // setup point coordinates
@@ -75,7 +64,7 @@ void Stk3DFMM::setPoints(const int nSL, const double *srcSLCoordPtr, const int n
     }
 
     if (stkfmm::verbose && rank == 0)
-        printf("points set\n");
+        std::cout << "points set\n";
 }
 
 void Stk3DFMM::setupTree(KERNEL kernel) {
@@ -127,7 +116,7 @@ void Stk3DFMM::clearFMM(KERNEL kernel) {
     if (it != poolFMM.end())
         it->second->clear();
     else {
-        printf("kernel not found\n");
+        std::cout << "kernel not found\n";
         std::exit(1);
     }
 }

--- a/Lib/src/StkWallFMM.cpp
+++ b/Lib/src/StkWallFMM.cpp
@@ -26,7 +26,7 @@ StkWallFMM::StkWallFMM(int multOrder_, int maxPts_, PAXIS pbc_, unsigned int ker
     }
 
     if (poolFMM.empty()) {
-        printf("Error: no kernel activated\n");
+        std::cout << "Error: no kernel activated\n";
     }
 }
 
@@ -45,8 +45,8 @@ void StkWallFMM::setPoints(const int nSL, const double *srcSLCoordPtr, const int
             //     printf("kernel %u \n", asInteger(fmm.second->kernelChoice));
             fmm.second->deleteTree();
         }
-        if (rank == 0)
-            printf("ALL FMM Tree Cleared\n");
+        if (verbose && rank == 0)
+            std::cout << "ALL FMM Tree Cleared\n";
     }
 
     // setup point coordinates
@@ -82,8 +82,8 @@ void StkWallFMM::setPoints(const int nSL, const double *srcSLCoordPtr, const int
     srcSLOriginCoordInternal.resize(3 * nSL);
     std::copy(srcSLCoordInternal.begin(), srcSLCoordInternal.begin() + 3 * nSL, srcSLOriginCoordInternal.begin());
 
-    if (rank == 0)
-        printf("points set\n");
+    if (verbose && rank == 0)
+        std::cout << "points set\n";
 }
 
 void StkWallFMM::setupTree(KERNEL kernel) {
@@ -101,7 +101,7 @@ void StkWallFMM::setupTree(KERNEL kernel) {
         poolFMM[KERNEL::LapQPGradGrad]->setupTree(srcSLImageCoordInternal, std::vector<double>(), trgCoordInternal,
                                                   srcSLCoordInternal.size() / 3, srcSLCoordInternal.data());
     } else {
-        printf("Kernel not supported\n");
+        std::cout << "Kernel not supported\n";
         std::exit(1);
     }
 }
@@ -132,7 +132,7 @@ void StkWallFMM::evaluateFMM(const KERNEL kernel, const int nSL, const double *s
             trgValuePtr[i] += trgValueInternal[i];
         }
     } else {
-        printf("Kernel not supported\n");
+        std::cout << "Kernel not supported\n";
         std::exit(1);
     }
 }
@@ -148,7 +148,7 @@ void StkWallFMM::clearFMM(KERNEL kernel) {
         poolFMM[KERNEL::LapPGradGrad]->clear();
         poolFMM[KERNEL::LapQPGradGrad]->clear();
     } else {
-        printf("Kernel not supported\n");
+        std::cout << "Kernel not supported\n";
         std::exit(1);
     }
 }


### PR DESCRIPTION
Allows for relatively trivial redirection of STKFMM log messages to other output streams