### PR TITLE
Set the result type of the wall FMM creator

### DIFF
--- a/Python/PySTKFMM.py
+++ b/Python/PySTKFMM.py
@@ -5,6 +5,7 @@ import enum
 
 lib = cdll.LoadLibrary("libSTKFMM_SHARED.so")
 lib.Stk3DFMM_create.restype = c_void_p
+lib.StkWallFMM_create.restype = c_void_p
 
 
 class PAXIS(enum.IntEnum):


### PR DESCRIPTION
Set the `ctypes` `restype` for a returned pointer, for `StkWallFMM` as is already there for `Stk3DFMM`.  This fixes segmentation faults for bigger addresses.