### PR TITLE
SCTL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SCTL"]
+	path = SCTL
+	url = https://github.com/dmalhotra/SCTL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SCTL"]
-	path = SCTL
-	url = https://github.com/dmalhotra/SCTL.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # using Visual Studio C++
 endif()
 
+# Add all the SCTL relevant flags
+add_compile_options(-DSCTL_QUAD_T=__float128 -DSCTL_HAVE_BLAS -DSCTL_HAVE_LAPACK -DSCTL_HAVE_FFTW -I${PROJECT_SOURCE_DIR}/SCTL/include)
+
 set(MPI_CXX_SKIP_MPICXX
     true
     CACHE BOOL "The MPI-2 C++ bindings are disabled.")

--- a/Lib/include/STKFMM/LaplaceLayerKernel.hpp
+++ b/Lib/include/STKFMM/LaplaceLayerKernel.hpp
@@ -219,15 +219,15 @@ struct laplace_quadp : public GenericKernel<laplace_quadp> {
         const VecType &dx = r[0], &dy = r[1], &dz = r[2];
         // clang-format on
 
-        VecType commonCoeff = f[0] * dx * dx;
+        VecType commonCoeff = sxx * dx * dx;
         commonCoeff += (sxy + syx) * dx * dy;
         commonCoeff += (sxz + szx) * dx * dz;
         commonCoeff += syy * dy * dy;
         commonCoeff += (syz + szy) * dy * dz;
         commonCoeff += szz * dz * dz;
-        commonCoeff *= (typename VecType::ScalarType)(-3.0);
+        commonCoeff *= (typename VecType::ScalarType)(3.0);
 
-        u[0] += (commonCoeff + r2 * (sxx + syy + szz)) * rinv5;
+        u[0] += (commonCoeff - r2 * (sxx + syy + szz)) * rinv5;
     }
 };
 

--- a/Lib/include/STKFMM/LaplaceLayerKernel.hpp
+++ b/Lib/include/STKFMM/LaplaceLayerKernel.hpp
@@ -24,77 +24,37 @@
  */
 namespace pvfmm {
 
-/**
- * @brief micro kernel for Laplace single layer potential + gradient
- *
- * @tparam Real_t
- * @tparam Real_t
- * @tparam rsqrt_intrin0<Vec_t>
- * @param src_coord
- * @param src_value
- * @param trg_coord
- * @param trg_value
- */
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER = 0>
-void laplace_p_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                       Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t tp = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t sv = bcast_intrin<Vec_t>(&src_value[0][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                tp = add_intrin(tp, mul_intrin(sv, rinv));
-            }
-            tp = add_intrin(mul_intrin(tp, oofp),
-                            load_intrin<Vec_t>(&trg_value[0][t])); // potential
-
-            store_intrin(&trg_value[0][t], tp);
-        }
-    }
-}
-
 template <class T>
-struct LaplaceLayerKernelNew {
-    // inline static const Kernel<T> &Grad();       ///< Laplace Grad Kernel, for test only
+
+/**
+ * @brief LaplaceLayerkernel class
+ *
+ * @tparam T float or double
+ */
+struct LaplaceLayerKernel {
+    // inline static const Kernel<T> &Grad();    ///< Laplace Grad Kernel, for test only
     inline static const Kernel<T> &PGrad();      ///< Laplace PGrad Kernel
     inline static const Kernel<T> &PGradGrad();  ///< Laplace PGradGrad
     inline static const Kernel<T> &QPGradGrad(); ///< Laplace Quadruple PGradGrad, no double layer
 };
 
-struct laplace_p_new : public GenericKernel<laplace_p_new> {
+struct laplace_p : public GenericKernel<laplace_p> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
         return 1.0 / (4.0 * const_pi<Real>());
     }
+
+    /**
+     * @brief micro kernel for Laplace single layer potential + gradient
+     *
+     * @tparam VecType
+     * @tparam digits
+     * @param trg_value
+     * @param src_coord
+     * @param trg_value
+     * @param ctx_ptr
+     */
     template <class VecType, int digits>
     static void uKerEval(VecType (&u)[1], const VecType (&r)[3], const VecType (&f)[1], const void *ctx_ptr) {
         VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
@@ -104,12 +64,23 @@ struct laplace_p_new : public GenericKernel<laplace_p_new> {
     }
 };
 
-struct laplace_pgrad_new : public GenericKernel<laplace_pgrad_new> {
+struct laplace_pgrad : public GenericKernel<laplace_pgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
         return 1.0 / (4.0 * const_pi<Real>());
     }
+
+    /**
+     * @brief micro kernel for Laplace single layer potential + gradient
+     *
+     * @tparam VecType
+     * @tparam digits
+     * @param trg_value
+     * @param src_coord
+     * @param trg_value
+     * @param ctx_ptr
+     */
     template <class VecType, int digits>
     static void uKerEval(VecType (&u)[4], const VecType (&r)[3], const VecType (&f)[1], const void *ctx_ptr) {
         VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
@@ -124,8 +95,7 @@ struct laplace_pgrad_new : public GenericKernel<laplace_pgrad_new> {
     }
 };
 
-
-struct laplace_dipolep_new : public GenericKernel<laplace_dipolep_new> {
+struct laplace_dipolep : public GenericKernel<laplace_dipolep> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -142,8 +112,7 @@ struct laplace_dipolep_new : public GenericKernel<laplace_dipolep_new> {
     }
 };
 
-
-struct laplace_dipolepgrad_new : public GenericKernel<laplace_dipolepgrad_new> {
+struct laplace_dipolepgrad : public GenericKernel<laplace_dipolepgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -166,7 +135,7 @@ struct laplace_dipolepgrad_new : public GenericKernel<laplace_dipolepgrad_new> {
     }
 };
 
-struct laplace_pgradgrad_new : public GenericKernel<laplace_pgradgrad_new> {
+struct laplace_pgradgrad : public GenericKernel<laplace_pgradgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -196,7 +165,7 @@ struct laplace_pgradgrad_new : public GenericKernel<laplace_pgradgrad_new> {
     }
 };
 
-struct laplace_dipolepgradgrad_new : public GenericKernel<laplace_dipolepgradgrad_new> {
+struct laplace_dipolepgradgrad : public GenericKernel<laplace_dipolepgradgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -230,7 +199,7 @@ struct laplace_dipolepgradgrad_new : public GenericKernel<laplace_dipolepgradgra
     }
 };
 
-struct laplace_quadp_new : public GenericKernel<laplace_quadp_new> {
+struct laplace_quadp : public GenericKernel<laplace_quadp> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -262,8 +231,7 @@ struct laplace_quadp_new : public GenericKernel<laplace_quadp_new> {
     }
 };
 
-
-struct laplace_quadpgradgrad_new : public GenericKernel<laplace_quadpgradgrad_new> {
+struct laplace_quadpgradgrad : public GenericKernel<laplace_quadpgradgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -307,8 +275,7 @@ struct laplace_quadpgradgrad_new : public GenericKernel<laplace_quadpgradgrad_ne
         VecType rksky = dx * sxy + dy * syy + dz * szy;
         VecType rkskz = dx * sxz + dy * syz + dz * szz;
 
-
-        u[0] += (commonCoeff3 - r2 * trace) * rinv5; //p
+        u[0] += (commonCoeff3 - r2 * trace) * rinv5; // p
         VecType px = dx * commonCoeff5 - r2 * (rksxk + rkskx + dx * trace);
         VecType py = dy * commonCoeff5 - r2 * (rksyk + rksky + dy * trace);
         VecType pz = dz * commonCoeff5 - r2 * (rkszk + rkskz + dz * trace);
@@ -344,735 +311,13 @@ struct laplace_quadpgradgrad_new : public GenericKernel<laplace_quadpgradgrad_ne
     }
 };
 
-
-template<class T> const Kernel<T>& LaplaceLayerKernelNew<T>::PGrad(){
-  static Kernel<T> lap_pker =
-      BuildKernel<T, laplace_p_new::Eval<T>, laplace_dipolep_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
-  lap_pker.surf_dim = 3;
-
-  static Kernel<T> lap_pgker = BuildKernel<T, laplace_pgrad_new::Eval<T>, laplace_dipolepgrad_new::Eval<T>>(
-      "laplace_PGrad", 3, std::pair<int, int>(1, 4), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL, &lap_pker,
-      NULL);
-  lap_pgker.surf_dim = 3;
-
-  return lap_pgker;
-}
-
 template <class T>
-inline const Kernel<T> &LaplaceLayerKernelNew<T>::PGradGrad() {
-
+const Kernel<T> &LaplaceLayerKernel<T>::PGrad() {
     static Kernel<T> lap_pker =
-        BuildKernel<T, laplace_p_new::Eval<T>, laplace_dipolep_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
+        BuildKernel<T, laplace_p::Eval<T>, laplace_dipolep::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
     lap_pker.surf_dim = 3;
 
-    static Kernel<T> lap_pgker = BuildKernel<T, laplace_pgradgrad_new::Eval<T>, laplace_dipolepgradgrad_new::Eval<T>>(
-        "laplace_PGradGrad", 3, std::pair<int, int>(1, 10), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL,
-        &lap_pker, NULL);
-    lap_pgker.surf_dim = 3;
-
-    return lap_pgker;
-}
-
-template <class T>
-inline const Kernel<T> &LaplaceLayerKernelNew<T>::QPGradGrad() {
-    static Kernel<T> lap_pker = BuildKernel<T, laplace_p_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
-    static Kernel<T> lap_pggker =
-        BuildKernel<T, laplace_pgradgrad_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 10));
-    static Kernel<T> lap_qpker = BuildKernel<T, laplace_quadp_new::Eval<T>>("laplace", 3, std::pair<int, int>(9, 1));
-
-    static Kernel<T> lap_pgker = BuildKernel<T, laplace_quadpgradgrad_new::Eval<T>>(
-        "laplace_QPGradGrad", 3, std::pair<int, int>(9, 10), &lap_qpker, &lap_qpker, NULL, //
-        &lap_pker, &lap_pker, &lap_pggker,                                                 //
-        &lap_pker, &lap_pggker);
-
-    return lap_pgker;
-}
-
-/**
- * @brief micro kernel for Laplace single layer potential + gradient
- *
- * @tparam Real_t
- * @tparam Real_t
- * @tparam rsqrt_intrin0<Vec_t>
- * @param src_coord
- * @param src_value
- * @param trg_coord
- * @param trg_value
- */
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER = 0>
-void laplace_pgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                           Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-    Vec_t noofp = set_intrin<Vec_t, Real_t>(-OOFP);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t tp = zero_intrin<Vec_t>();
-            Vec_t tv0 = zero_intrin<Vec_t>();
-            Vec_t tv1 = zero_intrin<Vec_t>();
-            Vec_t tv2 = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t sv = bcast_intrin<Vec_t>(&src_value[0][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t r3inv = mul_intrin(mul_intrin(rinv, rinv), rinv);
-
-                sv = mul_intrin(sv, r3inv);
-                tp = add_intrin(tp, mul_intrin(sv, r2));
-                tv0 = add_intrin(tv0, mul_intrin(sv, dx));
-                tv1 = add_intrin(tv1, mul_intrin(sv, dy));
-                tv2 = add_intrin(tv2, mul_intrin(sv, dz));
-            }
-            tp = add_intrin(mul_intrin(tp, oofp),
-                            load_intrin<Vec_t>(&trg_value[0][t])); // potential
-            tv0 = add_intrin(mul_intrin(tv0, noofp),
-                             load_intrin<Vec_t>(&trg_value[1][t])); // gradient
-            tv1 = add_intrin(mul_intrin(tv1, noofp), load_intrin<Vec_t>(&trg_value[2][t]));
-            tv2 = add_intrin(mul_intrin(tv2, noofp), load_intrin<Vec_t>(&trg_value[3][t]));
-            store_intrin(&trg_value[0][t], tp);
-            store_intrin(&trg_value[1][t], tv0);
-            store_intrin(&trg_value[2][t], tv1);
-            store_intrin(&trg_value[3][t], tv2);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER = 0>
-void laplace_pgradgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                               Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP5 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-    Vec_t noofp = set_intrin<Vec_t, Real_t>(-OOFP);
-    Vec_t oofp5 = set_intrin<Vec_t, Real_t>(OOFP5);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t tp = zero_intrin<Vec_t>();
-            Vec_t tv0 = zero_intrin<Vec_t>();
-            Vec_t tv1 = zero_intrin<Vec_t>();
-            Vec_t tv2 = zero_intrin<Vec_t>();
-            Vec_t gxx = zero_intrin<Vec_t>();
-            Vec_t gxy = zero_intrin<Vec_t>();
-            Vec_t gxz = zero_intrin<Vec_t>();
-            Vec_t gyy = zero_intrin<Vec_t>();
-            Vec_t gyz = zero_intrin<Vec_t>();
-            Vec_t gzz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t sv = bcast_intrin<Vec_t>(&src_value[0][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t r3inv = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                Vec_t r2inv = mul_intrin(rinv, rinv);
-
-                sv = mul_intrin(sv, r3inv);
-                tp = add_intrin(tp, mul_intrin(sv, r2));
-                tv0 = add_intrin(tv0, mul_intrin(sv, dx));
-                tv1 = add_intrin(tv1, mul_intrin(sv, dy));
-                tv2 = add_intrin(tv2, mul_intrin(sv, dz));
-                gxx = add_intrin(
-                    gxx, mul_intrin(sv, mul_intrin(r2inv, sub_intrin(mul_intrin(three, mul_intrin(dx, dx)), r2))));
-                gyy = add_intrin(
-                    gyy, mul_intrin(sv, mul_intrin(r2inv, sub_intrin(mul_intrin(three, mul_intrin(dy, dy)), r2))));
-                gzz = add_intrin(
-                    gzz, mul_intrin(sv, mul_intrin(r2inv, sub_intrin(mul_intrin(three, mul_intrin(dz, dz)), r2))));
-                gxy = add_intrin(gxy, mul_intrin(sv, mul_intrin(r2inv, mul_intrin(three, mul_intrin(dx, dy)))));
-                gxz = add_intrin(gxz, mul_intrin(sv, mul_intrin(r2inv, mul_intrin(three, mul_intrin(dx, dz)))));
-                gyz = add_intrin(gyz, mul_intrin(sv, mul_intrin(r2inv, mul_intrin(three, mul_intrin(dy, dz)))));
-            }
-            // potential
-            tp = add_intrin(mul_intrin(tp, oofp), load_intrin<Vec_t>(&trg_value[0][t]));
-            // gradient
-            tv0 = add_intrin(mul_intrin(tv0, noofp), load_intrin<Vec_t>(&trg_value[1][t]));
-            tv1 = add_intrin(mul_intrin(tv1, noofp), load_intrin<Vec_t>(&trg_value[2][t]));
-            tv2 = add_intrin(mul_intrin(tv2, noofp), load_intrin<Vec_t>(&trg_value[3][t]));
-            // grad grad, symmetric
-            gxx = add_intrin(mul_intrin(gxx, oofp5), load_intrin<Vec_t>(&trg_value[4][t]));
-            gxy = add_intrin(mul_intrin(gxy, oofp5), load_intrin<Vec_t>(&trg_value[5][t]));
-            gxz = add_intrin(mul_intrin(gxz, oofp5), load_intrin<Vec_t>(&trg_value[6][t]));
-            gyy = add_intrin(mul_intrin(gyy, oofp5), load_intrin<Vec_t>(&trg_value[7][t]));
-            gyz = add_intrin(mul_intrin(gyz, oofp5), load_intrin<Vec_t>(&trg_value[8][t]));
-            gzz = add_intrin(mul_intrin(gzz, oofp5), load_intrin<Vec_t>(&trg_value[9][t]));
-            store_intrin(&trg_value[0][t], tp);
-            store_intrin(&trg_value[1][t], tv0);
-            store_intrin(&trg_value[2][t], tv1);
-            store_intrin(&trg_value[3][t], tv2);
-            store_intrin(&trg_value[4][t], gxx);
-            store_intrin(&trg_value[5][t], gxy);
-            store_intrin(&trg_value[6][t], gxz);
-            store_intrin(&trg_value[7][t], gyy);
-            store_intrin(&trg_value[8][t], gyz);
-            store_intrin(&trg_value[9][t], gzz);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER = 0>
-void laplace_dipolep_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                             Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-            Vec_t tv = zero_intrin<Vec_t>();
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t sn0 = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sn1 = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sn2 = bcast_intrin<Vec_t>(&src_value[2][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t r3inv = mul_intrin(mul_intrin(rinv, rinv), rinv);
-
-                Vec_t rdotn = mul_intrin(sn0, dx);
-                rdotn = add_intrin(rdotn, mul_intrin(sn1, dy));
-                rdotn = add_intrin(rdotn, mul_intrin(sn2, dz));
-
-                tv = add_intrin(tv, mul_intrin(r3inv, rdotn));
-            }
-            tv = add_intrin(mul_intrin(tv, oofp), load_intrin<Vec_t>(&trg_value[0][t]));
-            store_intrin(&trg_value[0][t], tv);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void laplace_dipolepgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                 Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP2 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-    Vec_t oofp2 = set_intrin<Vec_t, Real_t>(OOFP2);
-    Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-            Vec_t tg0 = zero_intrin<Vec_t>();
-            Vec_t tg1 = zero_intrin<Vec_t>();
-            Vec_t tg2 = zero_intrin<Vec_t>();
-            Vec_t tv = zero_intrin<Vec_t>();
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t s0 = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t s1 = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t s2 = bcast_intrin<Vec_t>(&src_value[2][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t r3inv = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                Vec_t r5inv = mul_intrin(mul_intrin(rinv, rinv), r3inv);
-
-                Vec_t rdotn = mul_intrin(s0, dx);
-                rdotn = add_intrin(rdotn, mul_intrin(s1, dy));
-                rdotn = add_intrin(rdotn, mul_intrin(s2, dz));
-
-                tv = add_intrin(tv, mul_intrin(rdotn, r3inv));
-                tg0 = add_intrin(tg0, mul_intrin(mul_intrin(s0, r2), r5inv));
-                tg0 = add_intrin(tg0, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dx));
-                tg1 = add_intrin(tg1, mul_intrin(mul_intrin(s1, r2), r5inv));
-                tg1 = add_intrin(tg1, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dy));
-                tg2 = add_intrin(tg2, mul_intrin(mul_intrin(s2, r2), r5inv));
-                tg2 = add_intrin(tg2, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dz));
-            }
-            tv = add_intrin(mul_intrin(tv, oofp), load_intrin<Vec_t>(&trg_value[0][t]));
-            tg0 = add_intrin(mul_intrin(tg0, oofp2), load_intrin<Vec_t>(&trg_value[1][t]));
-            tg1 = add_intrin(mul_intrin(tg1, oofp2), load_intrin<Vec_t>(&trg_value[2][t]));
-            tg2 = add_intrin(mul_intrin(tg2, oofp2), load_intrin<Vec_t>(&trg_value[3][t]));
-            store_intrin(&trg_value[0][t], tv);
-            store_intrin(&trg_value[1][t], tg0);
-            store_intrin(&trg_value[2][t], tg1);
-            store_intrin(&trg_value[3][t], tg2);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void laplace_dipolepgradgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                     Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP5 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP7 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                                const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-    Vec_t oofp5 = set_intrin<Vec_t, Real_t>(OOFP5);
-    Vec_t oofp7 = set_intrin<Vec_t, Real_t>(OOFP7);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    Vec_t six = set_intrin<Vec_t, Real_t>(6.0);
-    Vec_t nine = set_intrin<Vec_t, Real_t>(9.0);
-    Vec_t fifteen = set_intrin<Vec_t, Real_t>(15.0);
-    Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-            Vec_t tv = zero_intrin<Vec_t>();
-            Vec_t tg0 = zero_intrin<Vec_t>();
-            Vec_t tg1 = zero_intrin<Vec_t>();
-            Vec_t tg2 = zero_intrin<Vec_t>();
-            Vec_t gxx = zero_intrin<Vec_t>();
-            Vec_t gxy = zero_intrin<Vec_t>();
-            Vec_t gxz = zero_intrin<Vec_t>();
-            Vec_t gyy = zero_intrin<Vec_t>();
-            Vec_t gyz = zero_intrin<Vec_t>();
-            Vec_t gzz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-                Vec_t s0 = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t s1 = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t s2 = bcast_intrin<Vec_t>(&src_value[2][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t r3inv = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                Vec_t r5inv = mul_intrin(mul_intrin(rinv, rinv), r3inv);
-                Vec_t r7inv = mul_intrin(mul_intrin(rinv, rinv), r5inv);
-
-                Vec_t rdotn = mul_intrin(s0, dx);
-                rdotn = add_intrin(rdotn, mul_intrin(s1, dy));
-                rdotn = add_intrin(rdotn, mul_intrin(s2, dz));
-
-                tv = add_intrin(tv, mul_intrin(rdotn, r3inv));
-                tg0 = add_intrin(tg0, mul_intrin(mul_intrin(s0, r2), r5inv));
-                tg0 = add_intrin(tg0, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dx));
-                tg1 = add_intrin(tg1, mul_intrin(mul_intrin(s1, r2), r5inv));
-                tg1 = add_intrin(tg1, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dy));
-                tg2 = add_intrin(tg2, mul_intrin(mul_intrin(s2, r2), r5inv));
-                tg2 = add_intrin(tg2, mul_intrin(mul_intrin(mul_intrin(rdotn, nthree), r5inv), dz));
-                gxx = add_intrin(gxx, mul_intrin(mul_intrin(mul_intrin(fifteen, mul_intrin(dx, dx)), rdotn), r7inv));
-                gxx = sub_intrin(gxx, mul_intrin(r7inv, mul_intrin(add_intrin(mul_intrin(three, rdotn),
-                                                                              mul_intrin(six, mul_intrin(dx, s0))),
-                                                                   r2)));
-                gyy = add_intrin(gyy, mul_intrin(mul_intrin(mul_intrin(fifteen, mul_intrin(dy, dy)), rdotn), r7inv));
-                gyy = sub_intrin(gyy, mul_intrin(r7inv, mul_intrin(add_intrin(mul_intrin(three, rdotn),
-                                                                              mul_intrin(six, mul_intrin(dy, s1))),
-                                                                   r2)));
-                gzz = add_intrin(gzz, mul_intrin(mul_intrin(mul_intrin(fifteen, mul_intrin(dz, dz)), rdotn), r7inv));
-                gzz = sub_intrin(gzz, mul_intrin(r7inv, mul_intrin(add_intrin(mul_intrin(three, rdotn),
-                                                                              mul_intrin(six, mul_intrin(dz, s2))),
-                                                                   r2)));
-                const Vec_t threer2 = mul_intrin(r2, three);
-                gxy = add_intrin(gxy, mul_intrin(r7inv, mul_intrin(fifteen, mul_intrin(dx, mul_intrin(dy, rdotn)))));
-                gxy = sub_intrin(
-                    gxy, mul_intrin(r7inv, mul_intrin(threer2, add_intrin(mul_intrin(dx, s1), mul_intrin(dy, s0)))));
-                gxz = add_intrin(gxz, mul_intrin(r7inv, mul_intrin(fifteen, mul_intrin(dx, mul_intrin(dz, rdotn)))));
-                gxz = sub_intrin(
-                    gxz, mul_intrin(r7inv, mul_intrin(threer2, add_intrin(mul_intrin(dx, s2), mul_intrin(dz, s0)))));
-                gyz = add_intrin(gyz, mul_intrin(r7inv, mul_intrin(fifteen, mul_intrin(dy, mul_intrin(dz, rdotn)))));
-                gyz = sub_intrin(
-                    gyz, mul_intrin(r7inv, mul_intrin(threer2, add_intrin(mul_intrin(dy, s2), mul_intrin(dz, s1)))));
-            }
-            tv = add_intrin(mul_intrin(tv, oofp), load_intrin<Vec_t>(&trg_value[0][t]));
-            tg0 = add_intrin(mul_intrin(tg0, oofp5), load_intrin<Vec_t>(&trg_value[1][t]));
-            tg1 = add_intrin(mul_intrin(tg1, oofp5), load_intrin<Vec_t>(&trg_value[2][t]));
-            tg2 = add_intrin(mul_intrin(tg2, oofp5), load_intrin<Vec_t>(&trg_value[3][t]));
-            gxx = add_intrin(mul_intrin(gxx, oofp7), load_intrin<Vec_t>(&trg_value[4][t]));
-            gxy = add_intrin(mul_intrin(gxy, oofp7), load_intrin<Vec_t>(&trg_value[5][t]));
-            gxz = add_intrin(mul_intrin(gxz, oofp7), load_intrin<Vec_t>(&trg_value[6][t]));
-            gyy = add_intrin(mul_intrin(gyy, oofp7), load_intrin<Vec_t>(&trg_value[7][t]));
-            gyz = add_intrin(mul_intrin(gyz, oofp7), load_intrin<Vec_t>(&trg_value[8][t]));
-            gzz = add_intrin(mul_intrin(gzz, oofp7), load_intrin<Vec_t>(&trg_value[9][t]));
-            store_intrin(&trg_value[0][t], tv);
-            store_intrin(&trg_value[1][t], tg0);
-            store_intrin(&trg_value[2][t], tg1);
-            store_intrin(&trg_value[3][t], tg2);
-            store_intrin(&trg_value[4][t], gxx);
-            store_intrin(&trg_value[5][t], gxy);
-            store_intrin(&trg_value[6][t], gxz);
-            store_intrin(&trg_value[7][t], gyy);
-            store_intrin(&trg_value[8][t], gyz);
-            store_intrin(&trg_value[9][t], gzz);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void laplace_quadp_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                           Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP5 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP7 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                                const_pi<Real_t>());
-    Vec_t oofp = set_intrin<Vec_t, Real_t>(OOFP);
-    Vec_t oofp5 = set_intrin<Vec_t, Real_t>(-OOFP5);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-            Vec_t p = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                const Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                const Vec_t rinv2 = mul_intrin(rinv, rinv);
-                const Vec_t rinv3 = mul_intrin(rinv, rinv2);
-                const Vec_t rinv5 = mul_intrin(rinv3, rinv2);
-
-                // commonCoeffn3 = -3 rj rk Djk
-                // commonCoeff5 = rj rk Djk
-                Vec_t commonCoeff = mul_intrin(sxx, mul_intrin(dx, dx));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxy, mul_intrin(dx, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxz, mul_intrin(dx, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syx, mul_intrin(dy, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syy, mul_intrin(dy, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syz, mul_intrin(dy, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szx, mul_intrin(dz, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szy, mul_intrin(dz, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szz, mul_intrin(dz, dz)));
-                Vec_t commonCoeffn3 = mul_intrin(commonCoeff, nthree);
-
-                Vec_t trace = add_intrin(add_intrin(sxx, syy), szz);
-                p = add_intrin(p, mul_intrin(add_intrin(commonCoeffn3, mul_intrin(r2, trace)), rinv5));
-            }
-            p = add_intrin(mul_intrin(p, oofp5), load_intrin<Vec_t>(&trg_value[0][t]));
-
-            store_intrin(&trg_value[0][t], p);
-        }
-    }
-}
-
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void laplace_quadpgradgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                   Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOFP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP5 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t OOFP7 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                                const_pi<Real_t>());
-    const Real_t OOFP9 = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                                nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    Vec_t oofp5 = set_intrin<Vec_t, Real_t>(-OOFP5);
-    Vec_t oofp7 = set_intrin<Vec_t, Real_t>(OOFP7);
-    Vec_t oofp9 = set_intrin<Vec_t, Real_t>(OOFP9);
-
-    Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    Vec_t onezerofive = set_intrin<Vec_t, Real_t>(105.0);
-    Vec_t six = set_intrin<Vec_t, Real_t>(6.0);
-    Vec_t nine = set_intrin<Vec_t, Real_t>(9.0);
-    Vec_t fifteen = set_intrin<Vec_t, Real_t>(15.0);
-    Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-    Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-    Vec_t onethree = set_intrin<Vec_t, Real_t>(1. / 3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-            Vec_t p = zero_intrin<Vec_t>();
-            // g
-            Vec_t gx = zero_intrin<Vec_t>();
-            Vec_t gy = zero_intrin<Vec_t>();
-            Vec_t gz = zero_intrin<Vec_t>();
-            // gg
-            Vec_t gxx = zero_intrin<Vec_t>();
-            Vec_t gxy = zero_intrin<Vec_t>();
-            Vec_t gxz = zero_intrin<Vec_t>();
-            Vec_t gyy = zero_intrin<Vec_t>();
-            Vec_t gyz = zero_intrin<Vec_t>();
-            Vec_t gzz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                const Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                const Vec_t rinv2 = mul_intrin(rinv, rinv);
-                const Vec_t rinv3 = mul_intrin(rinv, rinv2);
-                const Vec_t rinv5 = mul_intrin(rinv3, rinv2);
-                const Vec_t rinv7 = mul_intrin(rinv5, rinv2);
-                const Vec_t rinv9 = mul_intrin(rinv7, rinv2);
-
-                // commonCoeffn3 = -3 rk rl Qkl
-                // commonCoeff5 = 5 rk rl Qkl
-                Vec_t rrQ = dx * dx * sxx + dx * dy * sxy + dx * dz * sxz + dy * dx * syx + dy * dy * syy +
-                            dy * dz * syz + dz * dx * szx + dz * dy * szy + dz * dz * szz;
-                Vec_t commonCoeff5 = rrQ * five;
-                Vec_t commonCoeffn3 = rrQ * nthree;
-
-                Vec_t trace = sxx + syy + szz;
-
-                Vec_t rksxk = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, sxy), mul_intrin(dz, sxz)));
-                Vec_t rksyk = add_intrin(mul_intrin(dx, syx), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, syz)));
-                Vec_t rkszk = add_intrin(mul_intrin(dx, szx), add_intrin(mul_intrin(dy, szy), mul_intrin(dz, szz)));
-
-                Vec_t rkskx = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, syx), mul_intrin(dz, szx)));
-                Vec_t rksky = add_intrin(mul_intrin(dx, sxy), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, szy)));
-                Vec_t rkskz = add_intrin(mul_intrin(dx, sxz), add_intrin(mul_intrin(dy, syz), mul_intrin(dz, szz)));
-
-                p = add_intrin(p, mul_intrin(add_intrin(commonCoeffn3, mul_intrin(r2, trace)), rinv5));
-                Vec_t px = sub_intrin(mul_intrin(dx, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksxk, rkskx), mul_intrin(dx, trace))));
-                Vec_t py = sub_intrin(mul_intrin(dy, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksyk, rksky), mul_intrin(dy, trace))));
-                Vec_t pz = sub_intrin(mul_intrin(dz, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rkszk, rkskz), mul_intrin(dz, trace))));
-                gx = add_intrin(gx, mul_intrin(mul_intrin(px, nthree), rinv7));
-                gy = add_intrin(gy, mul_intrin(mul_intrin(py, nthree), rinv7));
-                gz = add_intrin(gz, mul_intrin(mul_intrin(pz, nthree), rinv7));
-                gxx = gxx + rinv9 * (onezerofive * dx * dx * rrQ -
-                                     r2 * fifteen * (rrQ + dx * two * (rksxk + rkskx) + dx * dx * trace) +
-                                     three * r2 * r2 * (trace + two * sxx));
-                gyy = gyy + rinv9 * (onezerofive * dy * dy * rrQ -
-                                     r2 * fifteen * (rrQ + dy * two * (rksyk + rksky) + dy * dy * trace) +
-                                     three * r2 * r2 * (trace + two * syy));
-                gzz = gzz + rinv9 * (onezerofive * dz * dz * rrQ -
-                                     r2 * fifteen * (rrQ + dz * two * (rkszk + rkskz) + dz * dz * trace) +
-                                     three * r2 * r2 * (trace + two * szz));
-                gxy = gxy +
-                      rinv9 * (onezerofive * (dx * dy * rrQ) -
-                               r2 * fifteen * ((dy * rksxk + dy * rkskx + dx * rksyk + dx * rksky) + dx * dy * trace) +
-                               three * r2 * r2 * (sxy + syx));
-                gxz = gxz +
-                      rinv9 * (onezerofive * (dx * dz * rrQ) -
-                               r2 * fifteen * ((dz * rksxk + dz * rkskx + dx * rkszk + dx * rkskz) + dx * dz * trace) +
-                               three * r2 * r2 * (sxz + szx));
-                gyz = gyz +
-                      rinv9 * (onezerofive * (dy * dz * rrQ) -
-                               r2 * fifteen * ((dy * rkszk + dy * rkskz + dz * rksyk + dz * rksky) + dy * dz * trace) +
-                               three * r2 * r2 * (syz + szy));
-            }
-            p = add_intrin(mul_intrin(p, oofp5), load_intrin<Vec_t>(&trg_value[0][t]));
-            gx = add_intrin(mul_intrin(gx, oofp7), load_intrin<Vec_t>(&trg_value[1][t]));
-            gy = add_intrin(mul_intrin(gy, oofp7), load_intrin<Vec_t>(&trg_value[2][t]));
-            gz = add_intrin(mul_intrin(gz, oofp7), load_intrin<Vec_t>(&trg_value[3][t]));
-            gxx = add_intrin(mul_intrin(gxx, oofp9), load_intrin<Vec_t>(&trg_value[4][t]));
-            gxy = add_intrin(mul_intrin(gxy, oofp9), load_intrin<Vec_t>(&trg_value[5][t]));
-            gxz = add_intrin(mul_intrin(gxz, oofp9), load_intrin<Vec_t>(&trg_value[6][t]));
-            gyy = add_intrin(mul_intrin(gyy, oofp9), load_intrin<Vec_t>(&trg_value[7][t]));
-            gyz = add_intrin(mul_intrin(gyz, oofp9), load_intrin<Vec_t>(&trg_value[8][t]));
-            gzz = add_intrin(mul_intrin(gzz, oofp9), load_intrin<Vec_t>(&trg_value[9][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], gx);
-            store_intrin(&trg_value[2][t], gy);
-            store_intrin(&trg_value[3][t], gz);
-            store_intrin(&trg_value[4][t], gxx);
-            store_intrin(&trg_value[5][t], gxy);
-            store_intrin(&trg_value[6][t], gxz);
-            store_intrin(&trg_value[7][t], gyy);
-            store_intrin(&trg_value[8][t], gyz);
-            store_intrin(&trg_value[9][t], gzz);
-        }
-    }
-}
-
-GEN_KERNEL(laplace_p, laplace_p_uKernel, 1, 1)
-GEN_KERNEL(laplace_pgrad, laplace_pgrad_uKernel, 1, 4)
-GEN_KERNEL(laplace_pgradgrad, laplace_pgradgrad_uKernel, 1, 10)
-GEN_KERNEL(laplace_dipolep, laplace_dipolep_uKernel, 3, 1)
-GEN_KERNEL(laplace_dipolepgrad, laplace_dipolepgrad_uKernel, 3, 4)
-GEN_KERNEL(laplace_dipolepgradgrad, laplace_dipolepgradgrad_uKernel, 3, 10)
-GEN_KERNEL(laplace_quadp, laplace_quadp_uKernel, 9, 1)
-GEN_KERNEL(laplace_quadpgradgrad, laplace_quadpgradgrad_uKernel, 9, 10)
-
-/**
- * @brief LaplaceLayerkernel class
- *
- * @tparam T float or double
- */
-template <class T>
-struct LaplaceLayerKernel {
-    // inline static const Kernel<T> &Grad();       ///< Laplace Grad Kernel, for test only
-    inline static const Kernel<T> &PGrad();      ///< Laplace PGrad Kernel
-    inline static const Kernel<T> &PGradGrad();  ///< Laplace PGradGrad
-    inline static const Kernel<T> &QPGradGrad(); ///< Laplace Quadruple PGradGrad, no double layer
-
-  private:
-    /**
-     * @brief number of Newton iteration times
-     *  generate NEWTON_ITE at compile time.
-     * 1 for float and 2 for double
-     *
-     */
-    static constexpr int NEWTON_ITE = sizeof(T) / 4;
-};
-
-// template <class T>
-// inline const Kernel<T> &LaplaceLayerKernel<T>::Grad() {
-
-//     static Kernel<T> potn_ker = BuildKernel<T, laplace_p<T, NEWTON_ITE>>("laplace", 3, std::pair<int, int>(1, 1));
-//     static Kernel<T> grad_ker =
-//         BuildKernel<T, laplace_grad<T, NEWTON_ITE>>("laplace_Grad", 3, std::pair<int, int>(1, 3), &potn_ker,
-//         &potn_ker,
-//                                                     NULL, &potn_ker, &potn_ker, NULL, &potn_ker, NULL);
-//     return grad_ker;
-// }
-
-template <class T>
-inline const Kernel<T> &LaplaceLayerKernel<T>::PGrad() {
-
-    static Kernel<T> lap_pker = BuildKernel<T, laplace_p<T, NEWTON_ITE>, laplace_dipolep<T, NEWTON_ITE>>(
-        "laplace", 3, std::pair<int, int>(1, 1));
-    lap_pker.surf_dim = 3;
-
-    static Kernel<T> lap_pgker = BuildKernel<T, laplace_pgrad<T, NEWTON_ITE>, laplace_dipolepgrad<T, NEWTON_ITE>>(
+    static Kernel<T> lap_pgker = BuildKernel<T, laplace_pgrad::Eval<T>, laplace_dipolepgrad::Eval<T>>(
         "laplace_PGrad", 3, std::pair<int, int>(1, 4), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL,
         &lap_pker, NULL);
     lap_pgker.surf_dim = 3;
@@ -1083,14 +328,13 @@ inline const Kernel<T> &LaplaceLayerKernel<T>::PGrad() {
 template <class T>
 inline const Kernel<T> &LaplaceLayerKernel<T>::PGradGrad() {
 
-    static Kernel<T> lap_pker = BuildKernel<T, laplace_p<T, NEWTON_ITE>, laplace_dipolep<T, NEWTON_ITE>>(
-        "laplace", 3, std::pair<int, int>(1, 1));
+    static Kernel<T> lap_pker =
+        BuildKernel<T, laplace_p::Eval<T>, laplace_dipolep::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
     lap_pker.surf_dim = 3;
 
-    static Kernel<T> lap_pgker =
-        BuildKernel<T, laplace_pgradgrad<T, NEWTON_ITE>, laplace_dipolepgradgrad<T, NEWTON_ITE>>(
-            "laplace_PGradGrad", 3, std::pair<int, int>(1, 10), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL,
-            &lap_pker, NULL);
+    static Kernel<T> lap_pgker = BuildKernel<T, laplace_pgradgrad::Eval<T>, laplace_dipolepgradgrad::Eval<T>>(
+        "laplace_PGradGrad", 3, std::pair<int, int>(1, 10), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL,
+        &lap_pker, NULL);
     lap_pgker.surf_dim = 3;
 
     return lap_pgker;
@@ -1098,13 +342,11 @@ inline const Kernel<T> &LaplaceLayerKernel<T>::PGradGrad() {
 
 template <class T>
 inline const Kernel<T> &LaplaceLayerKernel<T>::QPGradGrad() {
+    static Kernel<T> lap_pker = BuildKernel<T, laplace_p::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
+    static Kernel<T> lap_pggker = BuildKernel<T, laplace_pgradgrad::Eval<T>>("laplace", 3, std::pair<int, int>(1, 10));
+    static Kernel<T> lap_qpker = BuildKernel<T, laplace_quadp::Eval<T>>("laplace", 3, std::pair<int, int>(9, 1));
 
-    static Kernel<T> lap_pker = BuildKernel<T, laplace_p<T, NEWTON_ITE>>("laplace", 3, std::pair<int, int>(1, 1));
-    static Kernel<T> lap_pggker =
-        BuildKernel<T, laplace_pgradgrad<T, NEWTON_ITE>>("laplace", 3, std::pair<int, int>(1, 10));
-    static Kernel<T> lap_qpker = BuildKernel<T, laplace_quadp<T, NEWTON_ITE>>("laplace", 3, std::pair<int, int>(9, 1));
-
-    static Kernel<T> lap_pgker = BuildKernel<T, laplace_quadpgradgrad<T, NEWTON_ITE>>(
+    static Kernel<T> lap_pgker = BuildKernel<T, laplace_quadpgradgrad::Eval<T>>(
         "laplace_QPGradGrad", 3, std::pair<int, int>(9, 10), &lap_qpker, &lap_qpker, NULL, //
         &lap_pker, &lap_pker, &lap_pggker,                                                 //
         &lap_pker, &lap_pggker);

--- a/Lib/include/STKFMM/LaplaceLayerKernel.hpp
+++ b/Lib/include/STKFMM/LaplaceLayerKernel.hpp
@@ -230,6 +230,121 @@ struct laplace_dipolepgradgrad_new : public GenericKernel<laplace_dipolepgradgra
     }
 };
 
+struct laplace_quadp_new : public GenericKernel<laplace_quadp_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (4.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[1], const VecType (&r)[3], const VecType (&f)[9], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv5 = rinv * rinv;
+        rinv5 = rinv5 * rinv5 * rinv;
+
+        // clang-format off
+        const VecType &sxx = f[0], &sxy = f[1], &sxz = f[2];
+        const VecType &syx = f[3], &syy = f[4], &syz = f[5];
+        const VecType &szx = f[6], &szy = f[7], &szz = f[8];
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        // clang-format on
+
+        VecType commonCoeff = f[0] * dx * dx;
+        commonCoeff += (sxy + syx) * dx * dy;
+        commonCoeff += (sxz + szx) * dx * dz;
+        commonCoeff += syy * dy * dy;
+        commonCoeff += (syz + szy) * dy * dz;
+        commonCoeff += szz * dz * dz;
+        commonCoeff *= (typename VecType::ScalarType)(-3.0);
+
+        u[0] += (commonCoeff + r2 * (sxx + syy + szz)) * rinv5;
+    }
+};
+
+
+struct laplace_quadpgradgrad_new : public GenericKernel<laplace_quadpgradgrad_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (4.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[10], const VecType (&r)[3], const VecType (&f)[9], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv2 = rinv * rinv;
+        VecType rinv3 = rinv2 * rinv;
+        VecType rinv5 = rinv3 * rinv2;
+        VecType rinv7 = rinv5 * rinv2;
+        VecType rinv9 = rinv7 * rinv2;
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType five = (typename VecType::ScalarType)(5.0);
+        const VecType fifteen = (typename VecType::ScalarType)(15.0);
+        const VecType onezerofive = (typename VecType::ScalarType)(105.0);
+
+        // clang-format off
+        const VecType &sxx = f[0], &sxy = f[1], &sxz = f[2];
+        const VecType &syx = f[3], &syy = f[4], &syz = f[5];
+        const VecType &szx = f[6], &szy = f[7], &szz = f[8];
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        // clang-format on
+
+        VecType rrQ = dx * dx * sxx + dx * dy * (sxy + syx) + dx * dz * (sxz + szx) + dy * dy * syy +
+                      dy * dz * (syz + szy) + dz * dz * szz;
+
+        VecType commonCoeff3 = rrQ * three;
+        VecType commonCoeff5 = rrQ * five;
+
+        VecType trace = sxx + syy + szz;
+
+        VecType rksxk = dx * sxx + dy * sxy + dz * sxz;
+        VecType rksyk = dx * syx + dy * syy + dz * syz;
+        VecType rkszk = dx * szx + dy * szy + dz * szz;
+
+        VecType rkskx = dx * sxx + dy * syx + dz * szx;
+        VecType rksky = dx * sxy + dy * syy + dz * szy;
+        VecType rkskz = dx * sxz + dy * syz + dz * szz;
+
+
+        u[0] += (commonCoeff3 - r2 * trace) * rinv5; //p
+        VecType px = dx * commonCoeff5 - r2 * (rksxk + rkskx + dx * trace);
+        VecType py = dy * commonCoeff5 - r2 * (rksyk + rksky + dy * trace);
+        VecType pz = dz * commonCoeff5 - r2 * (rkszk + rkskz + dz * trace);
+
+        u[1] -= three * px * rinv7; // gx
+        u[2] -= three * py * rinv7; // gy
+        u[3] -= three * pz * rinv7; // gz
+
+        // gxx
+        u[4] +=
+            rinv9 * (onezerofive * dx * dx * rrQ - r2 * fifteen * (rrQ + dx * two * (rksxk + rkskx) + dx * dx * trace) +
+                     three * r2 * r2 * (trace + two * sxx));
+        // gxy
+        u[5] += rinv9 * (onezerofive * (dx * dy * rrQ) -
+                         r2 * fifteen * ((dy * rksxk + dy * rkskx + dx * rksyk + dx * rksky) + dx * dy * trace) +
+                         three * r2 * r2 * (sxy + syx));
+        // gxz
+        u[6] += rinv9 * (onezerofive * (dx * dz * rrQ) -
+                         r2 * fifteen * ((dz * rksxk + dz * rkskx + dx * rkszk + dx * rkskz) + dx * dz * trace) +
+                         three * r2 * r2 * (sxz + szx));
+        // gyy
+        u[7] +=
+            rinv9 * (onezerofive * dy * dy * rrQ - r2 * fifteen * (rrQ + dy * two * (rksyk + rksky) + dy * dy * trace) +
+                     three * r2 * r2 * (trace + two * syy));
+        // gyz
+        u[8] += rinv9 * (onezerofive * (dy * dz * rrQ) -
+                         r2 * fifteen * ((dy * rkszk + dy * rkskz + dz * rksyk + dz * rksky) + dy * dz * trace) +
+                         three * r2 * r2 * (syz + szy));
+        // gzz
+        u[9] +=
+            rinv9 * (onezerofive * dz * dz * rrQ - r2 * fifteen * (rrQ + dz * two * (rkszk + rkskz) + dz * dz * trace) +
+                     three * r2 * r2 * (trace + two * szz));
+    }
+};
+
+
 template<class T> const Kernel<T>& LaplaceLayerKernelNew<T>::PGrad(){
   static Kernel<T> lap_pker =
       BuildKernel<T, laplace_p_new::Eval<T>, laplace_dipolep_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
@@ -254,6 +369,21 @@ inline const Kernel<T> &LaplaceLayerKernelNew<T>::PGradGrad() {
         "laplace_PGradGrad", 3, std::pair<int, int>(1, 10), &lap_pker, &lap_pker, NULL, &lap_pker, &lap_pker, NULL,
         &lap_pker, NULL);
     lap_pgker.surf_dim = 3;
+
+    return lap_pgker;
+}
+
+template <class T>
+inline const Kernel<T> &LaplaceLayerKernelNew<T>::QPGradGrad() {
+    static Kernel<T> lap_pker = BuildKernel<T, laplace_p_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 1));
+    static Kernel<T> lap_pggker =
+        BuildKernel<T, laplace_pgradgrad_new::Eval<T>>("laplace", 3, std::pair<int, int>(1, 10));
+    static Kernel<T> lap_qpker = BuildKernel<T, laplace_quadp_new::Eval<T>>("laplace", 3, std::pair<int, int>(9, 1));
+
+    static Kernel<T> lap_pgker = BuildKernel<T, laplace_quadpgradgrad_new::Eval<T>>(
+        "laplace_QPGradGrad", 3, std::pair<int, int>(9, 10), &lap_qpker, &lap_qpker, NULL, //
+        &lap_pker, &lap_pker, &lap_pggker,                                                 //
+        &lap_pker, &lap_pggker);
 
     return lap_pgker;
 }

--- a/Lib/include/STKFMM/RPYKernel.hpp
+++ b/Lib/include/STKFMM/RPYKernel.hpp
@@ -9,6 +9,136 @@
 
 namespace pvfmm {
 
+struct rpy_u_new : public GenericKernel<rpy_u_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[3], const VecType (&r)[3], const VecType (&f)[4], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        VecType rinv5 = rinv3 * rinv * rinv;
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType one_over_three = (typename VecType::ScalarType)(0.3333333333333);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &a = f[3];
+        // clang-format on
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+        VecType three_fdotr_rinv5 = three * fdotr * rinv5;
+        VecType a2_over_three = one_over_three * a * a;
+        u[0] += (r2 * fx + dx * fdotr) * rinv3 + a2_over_three * (fx * rinv3 - three_fdotr_rinv5 * dx);
+        u[1] += (r2 * fy + dy * fdotr) * rinv3 + a2_over_three * (fy * rinv3 - three_fdotr_rinv5 * dy);
+        u[2] += (r2 * fz + dz * fdotr) * rinv3 + a2_over_three * (fz * rinv3 - three_fdotr_rinv5 * dz);
+    }
+};
+
+struct rpy_ulapu_new : public GenericKernel<rpy_ulapu_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[6], const VecType (&r)[3], const VecType (&f)[4], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        VecType rinv5 = rinv3 * rinv * rinv;
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType one_over_three = (typename VecType::ScalarType)(0.3333333333333);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &a = f[3];
+        // clang-format on
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+        VecType fdotr_rinv3 = fdotr * rinv3;
+        VecType three_fdotr_rinv5 = three * fdotr * rinv5;
+        VecType a2_over_three = one_over_three * a * a;
+
+        VecType cx = fx * rinv3 - three_fdotr_rinv5 * dx;
+        VecType cy = fy * rinv3 - three_fdotr_rinv5 * dy;
+        VecType cz = fz * rinv3 - three_fdotr_rinv5 * dz;
+
+        u[0] += fx * rinv + dx * fdotr_rinv3 + a2_over_three * cx;
+        u[1] += fy * rinv + dy * fdotr_rinv3 + a2_over_three * cy;
+        u[2] += fz * rinv + dz * fdotr_rinv3 + a2_over_three * cz;
+        u[3] += two * cx;
+        u[4] += two * cy;
+        u[5] += two * cz;
+    }
+};
+
+struct stk_ulapu_new : public GenericKernel<stk_ulapu_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[6], const VecType (&r)[3], const VecType (&f)[3], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        VecType rinv5 = rinv3 * rinv * rinv;
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        // clang-format on
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+        VecType fdotr_rinv3 = fdotr * rinv3;
+        VecType three_fdotr_rinv5 = three * fdotr * rinv5;
+
+        u[0] += fx * rinv + dx * fdotr_rinv3;
+        u[1] += fy * rinv + dy * fdotr_rinv3;
+        u[2] += fz * rinv + dz * fdotr_rinv3;
+
+        u[3] += two * (fx * rinv3 - three_fdotr_rinv5 * dx);
+        u[4] += two * (fy * rinv3 - three_fdotr_rinv5 * dy);
+        u[5] += two * (fz * rinv3 - three_fdotr_rinv5 * dz);
+    }
+};
+
+template <class T>
+struct RPYKernelNew {
+    inline static const Kernel<T> &ulapu(); //   3+1->6
+};
+
+template <class T>
+inline const Kernel<T> &RPYKernelNew<T>::ulapu() {
+
+    static Kernel<T> g_ker = StokesKernel<T>::velocity();
+    static Kernel<T> gr_ker = BuildKernel<T, rpy_u_new::Eval<T>>("rpy_u", 3, std::pair<int, int>(4, 3));
+
+    static Kernel<T> glapg_ker = BuildKernel<T, stk_ulapu_new::Eval<T>>("stk_ulapu", 3, std::pair<int, int>(3, 6));
+
+    static Kernel<T> grlapgr_ker = BuildKernel<T, rpy_ulapu_new::Eval<T>>("rpy_ulapu", 3, std::pair<int, int>(4, 6),
+                                                                            &gr_ker,    // k_s2m
+                                                                            &gr_ker,    // k_s2l
+                                                                            NULL,       // k_s2t
+                                                                            &g_ker,     // k_m2m
+                                                                            &g_ker,     // k_m2l
+                                                                            &glapg_ker, // k_m2t
+                                                                            &g_ker,     // k_l2l
+                                                                            &glapg_ker, // k_l2t
+                                                                            NULL);
+    return grlapgr_ker;
+}
+
 /**********************************************************
  *                                                        *
  *     RPY velocity kernel, source: 4, target: 3          *

--- a/Lib/include/STKFMM/RPYKernel.hpp
+++ b/Lib/include/STKFMM/RPYKernel.hpp
@@ -9,7 +9,12 @@
 
 namespace pvfmm {
 
-struct rpy_u_new : public GenericKernel<rpy_u_new> {
+/**********************************************************
+ *                                                        *
+ *     RPY velocity kernel, source: 4, target: 3          *
+ *           fx,fy,fz,a -> ux,uy,uz                       *
+ **********************************************************/
+struct rpy_u : public GenericKernel<rpy_u> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -39,7 +44,12 @@ struct rpy_u_new : public GenericKernel<rpy_u_new> {
     }
 };
 
-struct rpy_ulapu_new : public GenericKernel<rpy_ulapu_new> {
+/**********************************************************
+ *                                                        *
+ * RPY Force,a Vel,lapVel kernel, source: 4, target: 6    *
+ *       fx,fy,fz,a -> ux,uy,uz,lapux,lapuy,lapuz         *
+ **********************************************************/
+struct rpy_ulapu : public GenericKernel<rpy_ulapu> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -79,7 +89,12 @@ struct rpy_ulapu_new : public GenericKernel<rpy_ulapu_new> {
     }
 };
 
-struct stk_ulapu_new : public GenericKernel<stk_ulapu_new> {
+/**********************************************************
+ *                                                        *
+ * Stokes Force Vel,lapVel kernel,source: 3, target: 6    *
+ *       fx,fy,fz -> ux,uy,uz,lapux,lapuy,lapuz           *
+ **********************************************************/
+struct stk_ulapu : public GenericKernel<stk_ulapu> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -114,430 +129,27 @@ struct stk_ulapu_new : public GenericKernel<stk_ulapu_new> {
 };
 
 template <class T>
-struct RPYKernelNew {
-    inline static const Kernel<T> &ulapu(); //   3+1->6
-};
-
-template <class T>
-inline const Kernel<T> &RPYKernelNew<T>::ulapu() {
-
-    static Kernel<T> g_ker = StokesKernel<T>::velocity();
-    static Kernel<T> gr_ker = BuildKernel<T, rpy_u_new::Eval<T>>("rpy_u", 3, std::pair<int, int>(4, 3));
-
-    static Kernel<T> glapg_ker = BuildKernel<T, stk_ulapu_new::Eval<T>>("stk_ulapu", 3, std::pair<int, int>(3, 6));
-
-    static Kernel<T> grlapgr_ker = BuildKernel<T, rpy_ulapu_new::Eval<T>>("rpy_ulapu", 3, std::pair<int, int>(4, 6),
-                                                                            &gr_ker,    // k_s2m
-                                                                            &gr_ker,    // k_s2l
-                                                                            NULL,       // k_s2t
-                                                                            &g_ker,     // k_m2m
-                                                                            &g_ker,     // k_m2l
-                                                                            &glapg_ker, // k_m2t
-                                                                            &g_ker,     // k_l2l
-                                                                            &glapg_ker, // k_l2t
-                                                                            NULL);
-    return grlapgr_ker;
-}
-
-/**********************************************************
- *                                                        *
- *     RPY velocity kernel, source: 4, target: 3          *
- *           fx,fy,fz,a -> ux,uy,uz                       *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void rpy_u_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                   Matrix<Real_t> &trg_value) {
-
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    Vec_t FACV = set_intrin<Vec_t, Real_t>(1.0 / (8 * const_pi<Real_t>()));
-    Vec_t nwtn_factor = set_intrin<Vec_t, Real_t>(1.0 / nwtn_scal);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-
-    const Vec_t one_over_three = set_intrin<Vec_t, Real_t>(static_cast<Real_t>(1.0 / 3.0));
-
-    const size_t src_cnt_ = src_coord.Dim(1);
-    const size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = tx - bcast_intrin<Vec_t>(&src_coord[0][s]);
-                const Vec_t dy = ty - bcast_intrin<Vec_t>(&src_coord[1][s]);
-                const Vec_t dz = tz - bcast_intrin<Vec_t>(&src_coord[2][s]);
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t a = bcast_intrin<Vec_t>(&src_value[3][s]);
-
-                const Vec_t a2_over_three = mul_intrin(mul_intrin(a, a), one_over_three);
-                const Vec_t r2 = add_intrin(add_intrin(mul_intrin(dx, dx), mul_intrin(dy, dy)), mul_intrin(dz, dz));
-
-                const Vec_t rinv = mul_intrin(rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2), nwtn_factor);
-                const Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                const Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-                const Vec_t fdotr = add_intrin(add_intrin(mul_intrin(fx, dx), mul_intrin(fy, dy)), mul_intrin(fz, dz));
-
-                vx = add_intrin(vx, mul_intrin(add_intrin(mul_intrin(r2, fx), mul_intrin(dx, fdotr)), rinv3));
-                vy = add_intrin(vy, mul_intrin(add_intrin(mul_intrin(r2, fy), mul_intrin(dy, fdotr)), rinv3));
-                vz = add_intrin(vz, mul_intrin(add_intrin(mul_intrin(r2, fz), mul_intrin(dz, fdotr)), rinv3));
-                const Vec_t three_fdotr_rinv5 = mul_intrin(mul_intrin(three, fdotr), rinv5);
-
-                vx = add_intrin(vx, mul_intrin(a2_over_three,
-                                               sub_intrin(mul_intrin(fx, rinv3), mul_intrin(three_fdotr_rinv5, dx))));
-                vy = add_intrin(vy, mul_intrin(a2_over_three,
-                                               sub_intrin(mul_intrin(fy, rinv3), mul_intrin(three_fdotr_rinv5, dy))));
-                vz = add_intrin(vz, mul_intrin(a2_over_three,
-                                               sub_intrin(mul_intrin(fz, rinv3), mul_intrin(three_fdotr_rinv5, dz))));
-            }
-
-            vx = add_intrin(mul_intrin(vx, FACV), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, FACV), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, FACV), load_intrin<Vec_t>(&trg_value[2][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                        *
- * RPY Force,a Vel,lapVel kernel, source: 4, target: 6    *
- *       fx,fy,fz,a -> ux,uy,uz,lapux,lapuy,lapuz         *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void rpy_ulapu_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                       Matrix<Real_t> &trg_value) {
-
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Vec_t FACV = set_intrin<Vec_t, Real_t>(1.0 / (8 * const_pi<Real_t>()));
-    const Vec_t nwtn_factor = set_intrin<Vec_t, Real_t>(1.0 / nwtn_scal);
-    const Vec_t one_over_three = set_intrin<Vec_t, Real_t>(1.0 / 3.0);
-    const Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    const Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    const size_t src_cnt_ = src_coord.Dim(1);
-    const size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-            Vec_t lapvx = zero_intrin<Vec_t>();
-            Vec_t lapvy = zero_intrin<Vec_t>();
-            Vec_t lapvz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = tx - bcast_intrin<Vec_t>(&src_coord[0][s]);
-                const Vec_t dy = ty - bcast_intrin<Vec_t>(&src_coord[1][s]);
-                const Vec_t dz = tz - bcast_intrin<Vec_t>(&src_coord[2][s]);
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t a = bcast_intrin<Vec_t>(&src_value[3][s]);
-
-                const Vec_t a2_over_three = mul_intrin(mul_intrin(a, a), one_over_three);
-                const Vec_t r2 = add_intrin(add_intrin(mul_intrin(dx, dx), mul_intrin(dy, dy)), mul_intrin(dz, dz));
-
-                const Vec_t rinv = mul_intrin(rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2), nwtn_factor);
-                const Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                const Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-                const Vec_t fdotr = add_intrin(add_intrin(mul_intrin(fx, dx), mul_intrin(fy, dy)), mul_intrin(fz, dz));
-
-                const Vec_t three_fdotr_rinv5 = mul_intrin(mul_intrin(three, fdotr), rinv5);
-                const Vec_t cx = sub_intrin(mul_intrin(fx, rinv3), mul_intrin(three_fdotr_rinv5, dx));
-                const Vec_t cy = sub_intrin(mul_intrin(fy, rinv3), mul_intrin(three_fdotr_rinv5, dy));
-                const Vec_t cz = sub_intrin(mul_intrin(fz, rinv3), mul_intrin(three_fdotr_rinv5, dz));
-
-                const Vec_t fdotr_rinv3 = mul_intrin(fdotr, rinv3);
-                vx = add_intrin(vx, add_intrin(mul_intrin(fx, rinv),
-                                               add_intrin(mul_intrin(dx, fdotr_rinv3), mul_intrin(a2_over_three, cx))));
-                vy = add_intrin(vy, add_intrin(mul_intrin(fy, rinv),
-                                               add_intrin(mul_intrin(dy, fdotr_rinv3), mul_intrin(a2_over_three, cy))));
-                vz = add_intrin(vz, add_intrin(mul_intrin(fz, rinv),
-                                               add_intrin(mul_intrin(dz, fdotr_rinv3), mul_intrin(a2_over_three, cz))));
-
-                lapvx = add_intrin(lapvx, mul_intrin(two, cx));
-                lapvy = add_intrin(lapvy, mul_intrin(two, cy));
-                lapvz = add_intrin(lapvz, mul_intrin(two, cz));
-            }
-
-            vx = add_intrin(mul_intrin(vx, FACV), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, FACV), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, FACV), load_intrin<Vec_t>(&trg_value[2][t]));
-            lapvx = add_intrin(mul_intrin(lapvx, FACV), load_intrin<Vec_t>(&trg_value[3][t]));
-            lapvy = add_intrin(mul_intrin(lapvy, FACV), load_intrin<Vec_t>(&trg_value[4][t]));
-            lapvz = add_intrin(mul_intrin(lapvz, FACV), load_intrin<Vec_t>(&trg_value[5][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-            store_intrin(&trg_value[3][t], lapvx);
-            store_intrin(&trg_value[4][t], lapvy);
-            store_intrin(&trg_value[5][t], lapvz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                        *
- * Stokes Force Vel,lapVel kernel,source: 3, target: 6    *
- *       fx,fy,fz -> ux,uy,uz,lapux,lapuy,lapuz           *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stk_ulapu_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                       Matrix<Real_t> &trg_value) {
-
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Vec_t FACV = set_intrin<Vec_t, Real_t>(1.0 / (8 * const_pi<Real_t>()));
-    Vec_t nwtn_factor = set_intrin<Vec_t, Real_t>(1.0 / nwtn_scal);
-    Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-
-    const size_t src_cnt_ = src_coord.Dim(1);
-    const size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-            Vec_t lapvx = zero_intrin<Vec_t>();
-            Vec_t lapvy = zero_intrin<Vec_t>();
-            Vec_t lapvz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = tx - bcast_intrin<Vec_t>(&src_coord[0][s]);
-                const Vec_t dy = ty - bcast_intrin<Vec_t>(&src_coord[1][s]);
-                const Vec_t dz = tz - bcast_intrin<Vec_t>(&src_coord[2][s]);
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-
-                const Vec_t r2 = add_intrin(add_intrin(mul_intrin(dx, dx), mul_intrin(dy, dy)), mul_intrin(dz, dz));
-
-                const Vec_t rinv = mul_intrin(rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2), nwtn_factor);
-                const Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                const Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-                const Vec_t fdotr = add_intrin(add_intrin(mul_intrin(fx, dx), mul_intrin(fy, dy)), mul_intrin(fz, dz));
-
-                const Vec_t three_fdotr_rinv5 = mul_intrin(mul_intrin(three, fdotr), rinv5);
-                const Vec_t cx = sub_intrin(mul_intrin(fx, rinv3), mul_intrin(three_fdotr_rinv5, dx));
-                const Vec_t cy = sub_intrin(mul_intrin(fy, rinv3), mul_intrin(three_fdotr_rinv5, dy));
-                const Vec_t cz = sub_intrin(mul_intrin(fz, rinv3), mul_intrin(three_fdotr_rinv5, dz));
-
-                const Vec_t fdotr_rinv3 = mul_intrin(fdotr, rinv3);
-                vx = add_intrin(vx, add_intrin(mul_intrin(fx, rinv), mul_intrin(dx, fdotr_rinv3)));
-                vy = add_intrin(vy, add_intrin(mul_intrin(fy, rinv), mul_intrin(dy, fdotr_rinv3)));
-                vz = add_intrin(vz, add_intrin(mul_intrin(fz, rinv), mul_intrin(dz, fdotr_rinv3)));
-
-                lapvx = add_intrin(lapvx, mul_intrin(two, cx));
-                lapvy = add_intrin(lapvy, mul_intrin(two, cy));
-                lapvz = add_intrin(lapvz, mul_intrin(two, cz));
-            }
-
-            vx = add_intrin(mul_intrin(vx, FACV), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, FACV), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, FACV), load_intrin<Vec_t>(&trg_value[2][t]));
-            lapvx = add_intrin(mul_intrin(lapvx, FACV), load_intrin<Vec_t>(&trg_value[3][t]));
-            lapvy = add_intrin(mul_intrin(lapvy, FACV), load_intrin<Vec_t>(&trg_value[4][t]));
-            lapvz = add_intrin(mul_intrin(lapvz, FACV), load_intrin<Vec_t>(&trg_value[5][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-            store_intrin(&trg_value[3][t], lapvx);
-            store_intrin(&trg_value[4][t], lapvy);
-            store_intrin(&trg_value[5][t], lapvz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                        *
- *   Laplace quadrupole kernel,source: 4, target: 4       *
- *       fx,fy,fz,b -> phi,gradphix,gradphiy,gradphiz     *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void laplace_phigradphi_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                Matrix<Real_t> &trg_value) {
-
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Vec_t FACV = set_intrin<Vec_t, Real_t>(1.0 / (4.0 * const_pi<Real_t>()));
-    Vec_t nwtn_factor = set_intrin<Vec_t, Real_t>(1.0 / nwtn_scal);
-    Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-
-    const size_t src_cnt_ = src_coord.Dim(1);
-    const size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t phi = zero_intrin<Vec_t>();
-            Vec_t gradphix = zero_intrin<Vec_t>();
-            Vec_t gradphiy = zero_intrin<Vec_t>();
-            Vec_t gradphiz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = tx - bcast_intrin<Vec_t>(&src_coord[0][s]);
-                const Vec_t dy = ty - bcast_intrin<Vec_t>(&src_coord[1][s]);
-                const Vec_t dz = tz - bcast_intrin<Vec_t>(&src_coord[2][s]);
-                const Vec_t dx2 = mul_intrin(dx, dx);
-                const Vec_t dy2 = mul_intrin(dy, dy);
-                const Vec_t dz2 = mul_intrin(dz, dz);
-                const Vec_t dxdydz = mul_intrin(mul_intrin(dx, dy), dz);
-
-                Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t b2 = bcast_intrin<Vec_t>(&src_value[3][s]);
-                // All terms scale as b2 * f, so premultiply
-                b2 = mul_intrin(b2, b2);
-                fx = mul_intrin(b2, fx);
-                fy = mul_intrin(b2, fy);
-                fz = mul_intrin(b2, fz);
-
-                const Vec_t r2 = add_intrin(add_intrin(mul_intrin(dx, dx), mul_intrin(dy, dy)), mul_intrin(dz, dz));
-
-                const Vec_t rinv = mul_intrin(rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2), nwtn_factor);
-                const Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                const Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-                const Vec_t three_rinv5 = mul_intrin(three, rinv5);
-
-                // TODO: verify and optimize Laplace Quadrupole interaction
-                Vec_t Gzx = mul_intrin(mul_intrin(dx, dz), rinv3);
-                Vec_t Gzy = mul_intrin(mul_intrin(dy, dz), rinv3);
-                Vec_t Gxx_Gyy = add_intrin(add_intrin(rinv, rinv), mul_intrin(add_intrin(dx2, dy2), rinv3));
-
-                phi = add_intrin(
-                    phi, add_intrin(add_intrin(mul_intrin(Gzx, fx), mul_intrin(Gzy, fy)), mul_intrin(Gxx_Gyy, fz)));
-
-                gradphix = add_intrin(
-                    gradphix,
-                    mul_intrin(sub_intrin(mul_intrin(dz, rinv3), mul_intrin(mul_intrin(dx2, dz), three_rinv5)), fx));
-                gradphix = sub_intrin(gradphix, mul_intrin(mul_intrin(dxdydz, three_rinv5), fy));
-                gradphix = sub_intrin(gradphix, mul_intrin(mul_intrin(three_rinv5, fz),
-                                                           add_intrin(mul_intrin(dx, dx2), mul_intrin(dx, dy2))));
-
-                gradphiy = sub_intrin(gradphiy, mul_intrin(mul_intrin(dxdydz, three_rinv5), fx));
-                gradphiy = add_intrin(
-                    gradphiy,
-                    mul_intrin(sub_intrin(mul_intrin(dz, rinv3), mul_intrin(mul_intrin(dy2, dz), three_rinv5)), fy));
-                gradphiy = sub_intrin(gradphiy, mul_intrin(mul_intrin(three_rinv5, fz),
-                                                           add_intrin(mul_intrin(dy, dy2), mul_intrin(dy, dx2))));
-
-                gradphiz = add_intrin(
-                    gradphiz,
-                    mul_intrin(sub_intrin(mul_intrin(dx, rinv3), mul_intrin(mul_intrin(dz2, dx), three_rinv5)), fx));
-                gradphiz = add_intrin(
-                    gradphiz,
-                    mul_intrin(sub_intrin(mul_intrin(dy, rinv3), mul_intrin(mul_intrin(dz2, dy), three_rinv5)), fy));
-                gradphiz = sub_intrin(
-                    gradphiz, mul_intrin(add_intrin(mul_intrin(mul_intrin(two, dz), rinv3),
-                                                    mul_intrin(three_rinv5,
-                                                               add_intrin(mul_intrin(dx2, dz), mul_intrin(dy2, dz)))),
-                                         fz));
-            }
-
-            phi = add_intrin(mul_intrin(phi, FACV), load_intrin<Vec_t>(&trg_value[0][t]));
-            gradphix = add_intrin(mul_intrin(gradphix, FACV), load_intrin<Vec_t>(&trg_value[1][t]));
-            gradphiy = add_intrin(mul_intrin(gradphiy, FACV), load_intrin<Vec_t>(&trg_value[2][t]));
-            gradphiz = add_intrin(mul_intrin(gradphiz, FACV), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            store_intrin(&trg_value[0][t], phi);
-            store_intrin(&trg_value[1][t], gradphix);
-            store_intrin(&trg_value[2][t], gradphiy);
-            store_intrin(&trg_value[3][t], gradphiz);
-        }
-    }
-}
-
-GEN_KERNEL(rpy_u, rpy_u_uKernel, 4, 3)
-GEN_KERNEL(rpy_ulapu, rpy_ulapu_uKernel, 4, 6)
-GEN_KERNEL(stk_ulapu, stk_ulapu_uKernel, 3, 6)
-// GEN_KERNEL(laplace_phigradphi, laplace_phigradphi_uKernel, 4, 4)
-
-template <class T>
 struct RPYKernel {
     inline static const Kernel<T> &ulapu(); //   3+1->6
-  private:
-    static constexpr int NEWTON_ITE = sizeof(T) / 4;
 };
 
-// 1 newton for float, 2 newton for double
-// the string for stk_ker must be exactly the same as in kernel.txx of pvfmm
 template <class T>
 inline const Kernel<T> &RPYKernel<T>::ulapu() {
-
     static Kernel<T> g_ker = StokesKernel<T>::velocity();
-    static Kernel<T> gr_ker = BuildKernel<T, rpy_u<T, NEWTON_ITE>>("rpy_u", 3, std::pair<int, int>(4, 3));
+    static Kernel<T> gr_ker = BuildKernel<T, rpy_u::Eval<T>>("rpy_u", 3, std::pair<int, int>(4, 3));
 
-    static Kernel<T> glapg_ker = BuildKernel<T, stk_ulapu<T, NEWTON_ITE>>("stk_ulapu", 3, std::pair<int, int>(3, 6));
+    static Kernel<T> glapg_ker = BuildKernel<T, stk_ulapu::Eval<T>>("stk_ulapu", 3, std::pair<int, int>(3, 6));
 
-    static Kernel<T> grlapgr_ker = BuildKernel<T, rpy_ulapu<T, NEWTON_ITE>>("rpy_ulapu", 3, std::pair<int, int>(4, 6),
-                                                                            &gr_ker,    // k_s2m
-                                                                            &gr_ker,    // k_s2l
-                                                                            NULL,       // k_s2t
-                                                                            &g_ker,     // k_m2m
-                                                                            &g_ker,     // k_m2l
-                                                                            &glapg_ker, // k_m2t
-                                                                            &g_ker,     // k_l2l
-                                                                            &glapg_ker, // k_l2t
-                                                                            NULL);
+    static Kernel<T> grlapgr_ker = BuildKernel<T, rpy_ulapu::Eval<T>>("rpy_ulapu", 3, std::pair<int, int>(4, 6),
+                                                                      &gr_ker,    // k_s2m
+                                                                      &gr_ker,    // k_s2l
+                                                                      NULL,       // k_s2t
+                                                                      &g_ker,     // k_m2m
+                                                                      &g_ker,     // k_m2l
+                                                                      &glapg_ker, // k_m2t
+                                                                      &g_ker,     // k_l2l
+                                                                      &glapg_ker, // k_l2t
+                                                                      NULL);
     return grlapgr_ker;
 }
 

--- a/Lib/include/STKFMM/STKFMM_common.hpp
+++ b/Lib/include/STKFMM/STKFMM_common.hpp
@@ -1,14 +1,15 @@
 #ifndef STKFMM_COMMON_
 #define STKFMM_COMMON_
 
+#include <pvfmm.hpp>
+#include <intrin_wrapper.hpp>
+
 #include "LaplaceLayerKernel.hpp"
 #include "RPYKernel.hpp"
 #include "StokesLayerKernel.hpp"
 #include "StokesRegSingleLayerKernel.hpp"
 
 #include <unordered_map>
-
-#include <pvfmm.hpp>
 
 namespace stkfmm {
 /**

--- a/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
@@ -1,11 +1,11 @@
 /**
  * @file StokesDoubleLayerKernel.hpp
- * @author Wen Yan (wenyan4work@gmail.com)
+ * @author Wen Yan (wenyan4work@gmail.com), Robert Blackwell (rblackwell@flatironinstitute.org)
  * @brief Stokes double layer kernels
- * @version 0.1
- * @date 2019-12-23
+ * @version 0.2
+ * @date 2019-12-23, 2021-10-27
  *
- * @copyright Copyright (c) 2019
+ * @copyright Copyright (c) 2019, 2021
  *
  */
 #ifndef STOKESDOUBLELAYER_HPP_
@@ -15,12 +15,14 @@
 #include <cstdlib>
 #include <vector>
 
-#include "stkfmm_helpers.hpp"
-
 namespace pvfmm {
 
-
-struct stokes_doublepvel_new : public GenericKernel<stokes_doublepvel_new> {
+/*********************************************************
+ *                                                        *
+ *   Stokes Double P Vel kernel, source: 9, target: 4     *
+ *                                                        *
+ **********************************************************/
+struct stokes_doublepvel : public GenericKernel<stokes_doublepvel> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -54,8 +56,12 @@ struct stokes_doublepvel_new : public GenericKernel<stokes_doublepvel_new> {
     }
 };
 
-
-struct stokes_doublepvelgrad_new : public GenericKernel<stokes_doublepvelgrad_new> {
+/*********************************************************
+ *                                                        *
+ * Stokes Double P Vel Grad kernel, source: 9, target: 16 *
+ *                                                        *
+ **********************************************************/
+struct stokes_doublepvelgrad : public GenericKernel<stokes_doublepvelgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -87,7 +93,6 @@ struct stokes_doublepvelgrad_new : public GenericKernel<stokes_doublepvelgrad_ne
         VecType commonCoeff5 = (typename VecType::ScalarType)(5.0) * commonCoeff;
 
         const VecType trace = sxx + syy + szz;
-
 
         VecType rksxk = dx * sxx + dy * sxy + dz * sxz;
         VecType rksyk = dx * syx + dy * syy + dz * syz;
@@ -137,9 +142,12 @@ struct stokes_doublepvelgrad_new : public GenericKernel<stokes_doublepvelgrad_ne
     }
 };
 
-
-
-struct stokes_doublelaplacian_new : public GenericKernel<stokes_doublelaplacian_new> {
+/*********************************************************
+ *                                                        *
+ *  Stokes Double P Vel Lap kernel, source: 9, target: 7 *
+ *                                                        *
+ **********************************************************/
+struct stokes_doublelaplacian : public GenericKernel<stokes_doublelaplacian> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -172,7 +180,6 @@ struct stokes_doublelaplacian_new : public GenericKernel<stokes_doublelaplacian_
 
         const VecType trace = sxx + syy + szz;
 
-
         VecType rksxk = dx * sxx + dy * sxy + dz * sxz;
         VecType rksyk = dx * syx + dy * syy + dz * syz;
         VecType rkszk = dx * szx + dy * szy + dz * szz;
@@ -198,8 +205,12 @@ struct stokes_doublelaplacian_new : public GenericKernel<stokes_doublelaplacian_
     }
 };
 
-
-struct stokes_doubletraction_new : public GenericKernel<stokes_doubletraction_new> {
+/*********************************************************
+ *                                                        *
+ *   Stokes Double Traction kernel, source: 9, target: 9  *
+ *                                                        *
+ **********************************************************/
+struct stokes_doubletraction : public GenericKernel<stokes_doubletraction> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -260,712 +271,5 @@ struct stokes_doubletraction_new : public GenericKernel<stokes_doubletraction_ne
         u[8] += np + tv8 + tv8;
     }
 };
-
-/*********************************************************
- *                                                        *
- *   Stokes Double P Vel kernel, source: 9, target: 4     *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_doublepvel_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                               Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal);
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);     // vi = 1/8pi (-3rirjrk/r^5) Djk
-    const Vec_t facp = set_intrin<Vec_t, Real_t>(FACV * 2); // p = 1/4pi (-3 rjrk/r^5 + delta_jk/r^3) Djk
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv2 = mul_intrin(rinv, rinv);
-                Vec_t rinv4 = mul_intrin(rinv2, rinv2);
-
-                Vec_t rinv5 = mul_intrin(rinv, rinv4);
-
-                // commonCoeff = -3 rj rk Djk
-                Vec_t commonCoeff = mul_intrin(sxx, mul_intrin(dx, dx));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxy, mul_intrin(dx, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxz, mul_intrin(dx, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syx, mul_intrin(dy, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syy, mul_intrin(dy, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syz, mul_intrin(dy, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szx, mul_intrin(dz, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szy, mul_intrin(dz, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szz, mul_intrin(dz, dz)));
-                commonCoeff = mul_intrin(commonCoeff, nthree);
-
-                const Vec_t trace = add_intrin(add_intrin(sxx, syy), szz);
-                // p = add_intrin(p, mul_intrin(add_intrin(commonCoeff, mul_intrin(r2, trace)), rinv5));
-                p = add_intrin(p, mul_intrin(commonCoeff, rinv5));
-                p = add_intrin(p, mul_intrin(mul_intrin(r2, rinv5), trace));
-                vx = add_intrin(vx, mul_intrin(rinv5, mul_intrin(dx, commonCoeff)));
-                vy = add_intrin(vy, mul_intrin(rinv5, mul_intrin(dy, commonCoeff)));
-                vz = add_intrin(vz, mul_intrin(rinv5, mul_intrin(dz, commonCoeff)));
-            }
-
-            p = add_intrin(mul_intrin(p, facp), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_doublepvel, stokes_doublepvel_uKernel, 9, 4)
-
-/*********************************************************
- *                                                        *
- * Stokes Double P Vel Grad kernel, source: 9, target: 16 *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_doublepvelgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                   Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV5 = 1 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal);
-    const Vec_t facv5 = set_intrin<Vec_t, Real_t>(FACV5);     // vi = 1/8pi (-3rirjrk/r^5) Djk
-    const Vec_t facp5 = set_intrin<Vec_t, Real_t>(FACV5 * 2); // p = 1/4pi (-4 rjrk/r^5 + delta_jk) Djk
-
-    const Real_t FACV7 = 3 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                              nwtn_scal * nwtn_scal);
-    const Vec_t facv7 = set_intrin<Vec_t, Real_t>(-FACV7);    // -3/8pi
-    const Vec_t facp7 = set_intrin<Vec_t, Real_t>(FACV7 * 2); // 3/4pi(5 ... - ...)
-
-    const Vec_t none = set_intrin<Vec_t, Real_t>(-1.0);
-    const Vec_t ntwo = set_intrin<Vec_t, Real_t>(-2.0);
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-
-            // grad p
-            Vec_t pxSum = zero_intrin<Vec_t>();
-            Vec_t pySum = zero_intrin<Vec_t>();
-            Vec_t pzSum = zero_intrin<Vec_t>();
-
-            // grad v
-            Vec_t vxxSum = zero_intrin<Vec_t>();
-            Vec_t vxySum = zero_intrin<Vec_t>();
-            Vec_t vxzSum = zero_intrin<Vec_t>();
-
-            Vec_t vyxSum = zero_intrin<Vec_t>();
-            Vec_t vyySum = zero_intrin<Vec_t>();
-            Vec_t vyzSum = zero_intrin<Vec_t>();
-
-            Vec_t vzxSum = zero_intrin<Vec_t>();
-            Vec_t vzySum = zero_intrin<Vec_t>();
-            Vec_t vzzSum = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                const Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                const Vec_t rinv2 = mul_intrin(rinv, rinv);
-                const Vec_t rinv3 = mul_intrin(rinv, rinv2);
-                const Vec_t rinv5 = mul_intrin(rinv3, rinv2);
-                const Vec_t rinv7 = mul_intrin(rinv5, rinv2);
-
-                // commonCoeffn3 = -3 rj rk Djk
-                // commonCoeff5 = rj rk Djk
-                Vec_t commonCoeff = mul_intrin(sxx, mul_intrin(dx, dx));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxy, mul_intrin(dx, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxz, mul_intrin(dx, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syx, mul_intrin(dy, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syy, mul_intrin(dy, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syz, mul_intrin(dy, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szx, mul_intrin(dz, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szy, mul_intrin(dz, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szz, mul_intrin(dz, dz)));
-                Vec_t commonCoeff5 = mul_intrin(commonCoeff, five);
-                Vec_t commonCoeffn3 = mul_intrin(commonCoeff, nthree);
-
-                Vec_t trace = add_intrin(add_intrin(sxx, syy), szz);
-                Vec_t rksxk = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, sxy), mul_intrin(dz, sxz)));
-                Vec_t rksyk = add_intrin(mul_intrin(dx, syx), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, syz)));
-                Vec_t rkszk = add_intrin(mul_intrin(dx, szx), add_intrin(mul_intrin(dy, szy), mul_intrin(dz, szz)));
-
-                Vec_t rkskx = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, syx), mul_intrin(dz, szx)));
-                Vec_t rksky = add_intrin(mul_intrin(dx, sxy), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, szy)));
-                Vec_t rkskz = add_intrin(mul_intrin(dx, sxz), add_intrin(mul_intrin(dy, syz), mul_intrin(dz, szz)));
-
-                p = add_intrin(p, mul_intrin(add_intrin(commonCoeffn3, mul_intrin(r2, trace)), rinv5));
-                vx = add_intrin(vx, mul_intrin(rinv5, mul_intrin(dx, commonCoeffn3)));
-                vy = add_intrin(vy, mul_intrin(rinv5, mul_intrin(dy, commonCoeffn3)));
-                vz = add_intrin(vz, mul_intrin(rinv5, mul_intrin(dz, commonCoeffn3)));
-
-                // pgrad
-                Vec_t px = sub_intrin(mul_intrin(dx, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksxk, rkskx), mul_intrin(dx, trace))));
-                Vec_t py = sub_intrin(mul_intrin(dy, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksyk, rksky), mul_intrin(dy, trace))));
-                Vec_t pz = sub_intrin(mul_intrin(dz, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rkszk, rkskz), mul_intrin(dz, trace))));
-
-                pxSum = add_intrin(pxSum, mul_intrin(px, rinv7));
-                pySum = add_intrin(pySum, mul_intrin(py, rinv7));
-                pzSum = add_intrin(pzSum, mul_intrin(pz, rinv7));
-
-                // vgrad
-                Vec_t commonCoeffn1 = mul_intrin(none, commonCoeff);
-                // (-2*(t0 - s0)*sv0 - (t1 - s1)*(sv1 + sv3) - (t2 - s2)*(sv2 + sv6))
-                Vec_t dcFd0 = mul_intrin(ntwo, mul_intrin(dx, sxx));
-                dcFd0 = add_intrin(dcFd0, mul_intrin(none, mul_intrin(dy, add_intrin(sxy, syx))));
-                dcFd0 = add_intrin(dcFd0, mul_intrin(none, mul_intrin(dz, add_intrin(sxz, szx))));
-
-                // (-2*(t1 - s1)*sv4 - (t0 - s0)*(sv1 + sv3) - (t2 - s2)*(sv5 + sv7))
-                Vec_t dcFd1 = mul_intrin(ntwo, mul_intrin(dy, syy));
-                dcFd1 = add_intrin(dcFd1, mul_intrin(none, mul_intrin(dx, add_intrin(sxy, syx))));
-                dcFd1 = add_intrin(dcFd1, mul_intrin(none, mul_intrin(dz, add_intrin(syz, szy))));
-
-                // (-2*(t2 - s2)*sv8 - (t0 - s0)*(sv2 + sv6) - (t1 - s1)*(sv5 + sv7))
-                Vec_t dcFd2 = mul_intrin(ntwo, mul_intrin(dz, szz));
-                dcFd2 = add_intrin(dcFd2, mul_intrin(none, mul_intrin(dx, add_intrin(sxz, szx))));
-                dcFd2 = add_intrin(dcFd2, mul_intrin(none, mul_intrin(dy, add_intrin(syz, szy))));
-
-                Vec_t tv0 = zero_intrin<Vec_t>();
-                Vec_t tv1 = zero_intrin<Vec_t>();
-                Vec_t tv2 = zero_intrin<Vec_t>();
-                Vec_t tv3 = zero_intrin<Vec_t>();
-                Vec_t tv4 = zero_intrin<Vec_t>();
-                Vec_t tv5 = zero_intrin<Vec_t>();
-                Vec_t tv6 = zero_intrin<Vec_t>();
-                Vec_t tv7 = zero_intrin<Vec_t>();
-                Vec_t tv8 = zero_intrin<Vec_t>();
-
-                // (5 * rrtensor * commonCoeff / rnorm ^ 7
-                //  - r^2 Outer[Times, rvec, {dcFd0, dcFd1, dcFd2}] / rnorm ^7
-                //  - r^2 IdentityMatrix[3] * commonCoeff / rnorm ^ 7);
-                tv0 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dx)));
-                tv0 = add_intrin(tv0, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd0))));
-                tv0 = add_intrin(tv0, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv0 = mul_intrin(tv0, rinv7);
-                tv1 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dy)));
-                tv1 = add_intrin(tv1, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd1))));
-                tv1 = mul_intrin(tv1, rinv7);
-                tv2 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dz)));
-                tv2 = add_intrin(tv2, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd2))));
-                tv2 = mul_intrin(tv2, rinv7);
-
-                tv3 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dx)));
-                tv3 = add_intrin(tv3, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd0))));
-                tv3 = mul_intrin(tv3, rinv7);
-                tv4 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dy)));
-                tv4 = add_intrin(tv4, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd1))));
-                tv4 = add_intrin(tv4, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv4 = mul_intrin(tv4, rinv7);
-                tv5 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dz)));
-                tv5 = add_intrin(tv5, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd2))));
-                tv5 = mul_intrin(tv5, rinv7);
-
-                tv6 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dx)));
-                tv6 = add_intrin(tv6, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd0))));
-                tv6 = mul_intrin(tv6, rinv7);
-                tv7 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dy)));
-                tv7 = add_intrin(tv7, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd1))));
-                tv7 = mul_intrin(tv7, rinv7);
-                tv8 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dz)));
-                tv8 = add_intrin(tv8, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd2))));
-                tv8 = add_intrin(tv8, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv8 = mul_intrin(tv8, rinv7);
-
-                vxxSum = add_intrin(vxxSum, tv0);
-                vxySum = add_intrin(vxySum, tv1);
-                vxzSum = add_intrin(vxzSum, tv2);
-
-                vyxSum = add_intrin(vyxSum, tv3);
-                vyySum = add_intrin(vyySum, tv4);
-                vyzSum = add_intrin(vyzSum, tv5);
-
-                vzxSum = add_intrin(vzxSum, tv6);
-                vzySum = add_intrin(vzySum, tv7);
-                vzzSum = add_intrin(vzzSum, tv8);
-            }
-
-            p = add_intrin(mul_intrin(p, facp5), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv5), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv5), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv5), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            pxSum = add_intrin(mul_intrin(pxSum, facp7), load_intrin<Vec_t>(&trg_value[4][t]));
-            pySum = add_intrin(mul_intrin(pySum, facp7), load_intrin<Vec_t>(&trg_value[5][t]));
-            pzSum = add_intrin(mul_intrin(pzSum, facp7), load_intrin<Vec_t>(&trg_value[6][t]));
-
-            vxxSum = add_intrin(mul_intrin(vxxSum, facv7), load_intrin<Vec_t>(&trg_value[7][t]));
-            vxySum = add_intrin(mul_intrin(vxySum, facv7), load_intrin<Vec_t>(&trg_value[8][t]));
-            vxzSum = add_intrin(mul_intrin(vxzSum, facv7), load_intrin<Vec_t>(&trg_value[9][t]));
-
-            vyxSum = add_intrin(mul_intrin(vyxSum, facv7), load_intrin<Vec_t>(&trg_value[10][t]));
-            vyySum = add_intrin(mul_intrin(vyySum, facv7), load_intrin<Vec_t>(&trg_value[11][t]));
-            vyzSum = add_intrin(mul_intrin(vyzSum, facv7), load_intrin<Vec_t>(&trg_value[12][t]));
-
-            vzxSum = add_intrin(mul_intrin(vzxSum, facv7), load_intrin<Vec_t>(&trg_value[13][t]));
-            vzySum = add_intrin(mul_intrin(vzySum, facv7), load_intrin<Vec_t>(&trg_value[14][t]));
-            vzzSum = add_intrin(mul_intrin(vzzSum, facv7), load_intrin<Vec_t>(&trg_value[15][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-
-            store_intrin(&trg_value[4][t], pxSum);
-            store_intrin(&trg_value[5][t], pySum);
-            store_intrin(&trg_value[6][t], pzSum);
-
-            store_intrin(&trg_value[7][t], vxxSum);
-            store_intrin(&trg_value[8][t], vxySum);
-            store_intrin(&trg_value[9][t], vxzSum);
-
-            store_intrin(&trg_value[10][t], vyxSum);
-            store_intrin(&trg_value[11][t], vyySum);
-            store_intrin(&trg_value[12][t], vyzSum);
-
-            store_intrin(&trg_value[13][t], vzxSum);
-            store_intrin(&trg_value[14][t], vzySum);
-            store_intrin(&trg_value[15][t], vzzSum);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_doublepvelgrad, stokes_doublepvelgrad_uKernel, 9, 16)
-
-/*********************************************************
- *                                                        *
- *  Stokes Double P Vel Lap kernel, source: 9, target: 7 *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_doublelaplacian_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                    Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV5 = 1 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal);
-    const Vec_t facv5 = set_intrin<Vec_t, Real_t>(FACV5);     // vi = 1/8pi (-3rirjrk/r^5) Djk
-    const Vec_t facp5 = set_intrin<Vec_t, Real_t>(FACV5 * 2); // p = 1/4pi (-4 rjrk/r^5 + delta_jk) Djk
-
-    const Real_t FACV7 = 3 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                              nwtn_scal * nwtn_scal);
-    const Vec_t facv7 = set_intrin<Vec_t, Real_t>(-FACV7);    // -3/8pi
-    const Vec_t facp7 = set_intrin<Vec_t, Real_t>(FACV7 * 2); // 3/4pi(5 ... - ...)
-
-    const Vec_t none = set_intrin<Vec_t, Real_t>(-1.0);
-    const Vec_t ntwo = set_intrin<Vec_t, Real_t>(-2.0);
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();
-            Vec_t vx = zero_intrin<Vec_t>();
-            Vec_t vy = zero_intrin<Vec_t>();
-            Vec_t vz = zero_intrin<Vec_t>();
-
-            // grad p
-            Vec_t pxSum = zero_intrin<Vec_t>();
-            Vec_t pySum = zero_intrin<Vec_t>();
-            Vec_t pzSum = zero_intrin<Vec_t>();
-
-            // grad v
-            Vec_t vxxSum = zero_intrin<Vec_t>();
-            Vec_t vxySum = zero_intrin<Vec_t>();
-            Vec_t vxzSum = zero_intrin<Vec_t>();
-
-            Vec_t vyxSum = zero_intrin<Vec_t>();
-            Vec_t vyySum = zero_intrin<Vec_t>();
-            Vec_t vyzSum = zero_intrin<Vec_t>();
-
-            Vec_t vzxSum = zero_intrin<Vec_t>();
-            Vec_t vzySum = zero_intrin<Vec_t>();
-            Vec_t vzzSum = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                const Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                const Vec_t rinv2 = mul_intrin(rinv, rinv);
-                const Vec_t rinv3 = mul_intrin(rinv, rinv2);
-                const Vec_t rinv5 = mul_intrin(rinv3, rinv2);
-                const Vec_t rinv7 = mul_intrin(rinv5, rinv2);
-
-                // commonCoeffn3 = -3 rj rk Djk
-                // commonCoeff5 = rj rk Djk
-                Vec_t commonCoeff = mul_intrin(sxx, mul_intrin(dx, dx));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxy, mul_intrin(dx, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxz, mul_intrin(dx, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syx, mul_intrin(dy, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syy, mul_intrin(dy, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syz, mul_intrin(dy, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szx, mul_intrin(dz, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szy, mul_intrin(dz, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szz, mul_intrin(dz, dz)));
-                Vec_t commonCoeff5 = mul_intrin(commonCoeff, five);
-                Vec_t commonCoeffn3 = mul_intrin(commonCoeff, nthree);
-
-                Vec_t trace = add_intrin(add_intrin(sxx, syy), szz);
-                Vec_t rksxk = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, sxy), mul_intrin(dz, sxz)));
-                Vec_t rksyk = add_intrin(mul_intrin(dx, syx), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, syz)));
-                Vec_t rkszk = add_intrin(mul_intrin(dx, szx), add_intrin(mul_intrin(dy, szy), mul_intrin(dz, szz)));
-
-                Vec_t rkskx = add_intrin(mul_intrin(dx, sxx), add_intrin(mul_intrin(dy, syx), mul_intrin(dz, szx)));
-                Vec_t rksky = add_intrin(mul_intrin(dx, sxy), add_intrin(mul_intrin(dy, syy), mul_intrin(dz, szy)));
-                Vec_t rkskz = add_intrin(mul_intrin(dx, sxz), add_intrin(mul_intrin(dy, syz), mul_intrin(dz, szz)));
-
-                p = add_intrin(p, mul_intrin(add_intrin(commonCoeffn3, mul_intrin(r2, trace)), rinv5));
-                vx = add_intrin(vx, mul_intrin(rinv5, mul_intrin(dx, commonCoeffn3)));
-                vy = add_intrin(vy, mul_intrin(rinv5, mul_intrin(dy, commonCoeffn3)));
-                vz = add_intrin(vz, mul_intrin(rinv5, mul_intrin(dz, commonCoeffn3)));
-
-                // lap v = pgrad
-                Vec_t px = sub_intrin(mul_intrin(dx, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksxk, rkskx), mul_intrin(dx, trace))));
-                Vec_t py = sub_intrin(mul_intrin(dy, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rksyk, rksky), mul_intrin(dy, trace))));
-                Vec_t pz = sub_intrin(mul_intrin(dz, commonCoeff5),
-                                      mul_intrin(r2, add_intrin(add_intrin(rkszk, rkskz), mul_intrin(dz, trace))));
-
-                pxSum = add_intrin(pxSum, mul_intrin(px, rinv7));
-                pySum = add_intrin(pySum, mul_intrin(py, rinv7));
-                pzSum = add_intrin(pzSum, mul_intrin(pz, rinv7));
-            }
-
-            p = add_intrin(mul_intrin(p, facp5), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv5), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv5), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv5), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            pxSum = add_intrin(mul_intrin(pxSum, facp7), load_intrin<Vec_t>(&trg_value[4][t]));
-            pySum = add_intrin(mul_intrin(pySum, facp7), load_intrin<Vec_t>(&trg_value[5][t]));
-            pzSum = add_intrin(mul_intrin(pzSum, facp7), load_intrin<Vec_t>(&trg_value[6][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-
-            store_intrin(&trg_value[4][t], pxSum);
-            store_intrin(&trg_value[5][t], pySum);
-            store_intrin(&trg_value[6][t], pzSum);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_doublelaplacian, stokes_doublelaplacian_uKernel, 9, 7)
-
-/*********************************************************
- *                                                        *
- *   Stokes Double Traction kernel, source: 9, target: 9  *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_doubletraction_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                   Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-
-    const Real_t FACV7 = 3 / (8 * const_pi<Real_t>() * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal *
-                              nwtn_scal * nwtn_scal);
-    const Vec_t facv7 = set_intrin<Vec_t, Real_t>(-FACV7); // -3/8pi
-
-    const Vec_t facp = set_intrin<Vec_t, Real_t>((Real_t)(2.0 / 3.0));
-    const Vec_t none = set_intrin<Vec_t, Real_t>(-1.0);
-    const Vec_t ntwo = set_intrin<Vec_t, Real_t>(-2.0);
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            // traction
-            Vec_t txxSum = zero_intrin<Vec_t>();
-            Vec_t txySum = zero_intrin<Vec_t>();
-            Vec_t txzSum = zero_intrin<Vec_t>();
-
-            Vec_t tyxSum = zero_intrin<Vec_t>();
-            Vec_t tyySum = zero_intrin<Vec_t>();
-            Vec_t tyzSum = zero_intrin<Vec_t>();
-
-            Vec_t tzxSum = zero_intrin<Vec_t>();
-            Vec_t tzySum = zero_intrin<Vec_t>();
-            Vec_t tzzSum = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                // sxx,sxy,sxz,...,szz
-                Vec_t sxx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sxy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sxz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t syx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                Vec_t syy = bcast_intrin<Vec_t>(&src_value[4][s]);
-                Vec_t syz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                Vec_t szx = bcast_intrin<Vec_t>(&src_value[6][s]);
-                Vec_t szy = bcast_intrin<Vec_t>(&src_value[7][s]);
-                Vec_t szz = bcast_intrin<Vec_t>(&src_value[8][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                const Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                const Vec_t rinv2 = mul_intrin(rinv, rinv);
-                const Vec_t rinv3 = mul_intrin(rinv, rinv2);
-                const Vec_t rinv5 = mul_intrin(rinv3, rinv2);
-                const Vec_t rinv7 = mul_intrin(rinv5, rinv2);
-
-                Vec_t np = zero_intrin<Vec_t>();
-
-                // commonCoeffn3 = -3 rj rk Djk
-                // commonCoeff5 = 5 rj rk Djk
-                Vec_t commonCoeff = mul_intrin(sxx, mul_intrin(dx, dx));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxy, mul_intrin(dx, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sxz, mul_intrin(dx, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syx, mul_intrin(dy, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syy, mul_intrin(dy, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(syz, mul_intrin(dy, dz)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szx, mul_intrin(dz, dx)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szy, mul_intrin(dz, dy)));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(szz, mul_intrin(dz, dz)));
-                Vec_t commonCoeff5 = mul_intrin(commonCoeff, five);
-                Vec_t commonCoeffn3 = mul_intrin(commonCoeff, nthree);
-
-                Vec_t trace = add_intrin(add_intrin(sxx, syy), szz);
-
-                // np =
-                // mul_intrin(mul_intrin(mul_intrin(add_intrin(commonCoeffn3,
-                // mul_intrin(r2, trace)), rinv7), r2), none);
-                np = mul_intrin(mul_intrin(mul_intrin(add_intrin(commonCoeffn3, mul_intrin(r2, trace)), rinv7), r2),
-                                facp);
-
-                // vgrad
-                Vec_t commonCoeffn1 = mul_intrin(none, commonCoeff);
-                // (-2*(t0 - s0)*sv0 - (t1 - s1)*(sv1 + sv3) - (t2 - s2)*(sv2 + sv6))
-                Vec_t dcFd0 = mul_intrin(ntwo, mul_intrin(dx, sxx));
-                dcFd0 = add_intrin(dcFd0, mul_intrin(none, mul_intrin(dy, add_intrin(sxy, syx))));
-                dcFd0 = add_intrin(dcFd0, mul_intrin(none, mul_intrin(dz, add_intrin(sxz, szx))));
-
-                // (-2*(t1 - s1)*sv4 - (t0 - s0)*(sv1 + sv3) - (t2 - s2)*(sv5 + sv7))
-                Vec_t dcFd1 = mul_intrin(ntwo, mul_intrin(dy, syy));
-                dcFd1 = add_intrin(dcFd1, mul_intrin(none, mul_intrin(dx, add_intrin(sxy, syx))));
-                dcFd1 = add_intrin(dcFd1, mul_intrin(none, mul_intrin(dz, add_intrin(syz, szy))));
-
-                // (-2*(t2 - s2)*sv8 - (t0 - s0)*(sv2 + sv6) - (t1 - s1)*(sv5 + sv7))
-                Vec_t dcFd2 = mul_intrin(ntwo, mul_intrin(dz, szz));
-                dcFd2 = add_intrin(dcFd2, mul_intrin(none, mul_intrin(dx, add_intrin(sxz, szx))));
-                dcFd2 = add_intrin(dcFd2, mul_intrin(none, mul_intrin(dy, add_intrin(syz, szy))));
-
-                // grad u
-                Vec_t tv0 = zero_intrin<Vec_t>();
-                Vec_t tv1 = zero_intrin<Vec_t>();
-                Vec_t tv2 = zero_intrin<Vec_t>();
-                Vec_t tv3 = zero_intrin<Vec_t>();
-                Vec_t tv4 = zero_intrin<Vec_t>();
-                Vec_t tv5 = zero_intrin<Vec_t>();
-                Vec_t tv6 = zero_intrin<Vec_t>();
-                Vec_t tv7 = zero_intrin<Vec_t>();
-                Vec_t tv8 = zero_intrin<Vec_t>();
-
-                // (5 * rrtensor * commonCoeff / rnorm ^ 7
-                //  - r^2 Outer[Times, rvec, {dcFd0, dcFd1, dcFd2}] / rnorm ^7
-                //  - r^2 IdentityMatrix[3] * commonCoeff / rnorm ^ 7);
-                tv0 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dx)));
-                tv0 = add_intrin(tv0, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd0))));
-                tv0 = add_intrin(tv0, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv0 = mul_intrin(tv0, rinv7);
-                tv1 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dy)));
-                tv1 = add_intrin(tv1, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd1))));
-                tv1 = mul_intrin(tv1, rinv7);
-                tv2 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dx, dz)));
-                tv2 = add_intrin(tv2, mul_intrin(none, mul_intrin(r2, mul_intrin(dx, dcFd2))));
-                tv2 = mul_intrin(tv2, rinv7);
-
-                tv3 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dx)));
-                tv3 = add_intrin(tv3, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd0))));
-                tv3 = mul_intrin(tv3, rinv7);
-                tv4 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dy)));
-                tv4 = add_intrin(tv4, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd1))));
-                tv4 = add_intrin(tv4, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv4 = mul_intrin(tv4, rinv7);
-                tv5 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dy, dz)));
-                tv5 = add_intrin(tv5, mul_intrin(none, mul_intrin(r2, mul_intrin(dy, dcFd2))));
-                tv5 = mul_intrin(tv5, rinv7);
-
-                tv6 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dx)));
-                tv6 = add_intrin(tv6, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd0))));
-                tv6 = mul_intrin(tv6, rinv7);
-                tv7 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dy)));
-                tv7 = add_intrin(tv7, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd1))));
-                tv7 = mul_intrin(tv7, rinv7);
-                tv8 = mul_intrin(five, mul_intrin(commonCoeffn1, mul_intrin(dz, dz)));
-                tv8 = add_intrin(tv8, mul_intrin(none, mul_intrin(r2, mul_intrin(dz, dcFd2))));
-                tv8 = add_intrin(tv8, mul_intrin(none, mul_intrin(r2, commonCoeffn1)));
-                tv8 = mul_intrin(tv8, rinv7);
-
-                // traction = -p \delta_{ij} + d u_i / d x_j + d u_j / d x_i
-                txxSum = add_intrin(txxSum, add_intrin(np, add_intrin(tv0, tv0)));
-                txySum = add_intrin(txySum, add_intrin(tv1, tv3));
-                txzSum = add_intrin(txzSum, add_intrin(tv2, tv6));
-
-                tyxSum = add_intrin(tyxSum, add_intrin(tv1, tv3));
-                tyySum = add_intrin(tyySum, add_intrin(np, add_intrin(tv4, tv4)));
-                tyzSum = add_intrin(tyzSum, add_intrin(tv5, tv7));
-
-                tzxSum = add_intrin(tzxSum, add_intrin(tv2, tv6));
-                tzySum = add_intrin(tzySum, add_intrin(tv5, tv7));
-                tzzSum = add_intrin(tzzSum, add_intrin(np, add_intrin(tv8, tv8)));
-            }
-
-            txxSum = add_intrin(mul_intrin(txxSum, facv7), load_intrin<Vec_t>(&trg_value[0][t]));
-            txySum = add_intrin(mul_intrin(txySum, facv7), load_intrin<Vec_t>(&trg_value[1][t]));
-            txzSum = add_intrin(mul_intrin(txzSum, facv7), load_intrin<Vec_t>(&trg_value[2][t]));
-
-            tyxSum = add_intrin(mul_intrin(tyxSum, facv7), load_intrin<Vec_t>(&trg_value[3][t]));
-            tyySum = add_intrin(mul_intrin(tyySum, facv7), load_intrin<Vec_t>(&trg_value[4][t]));
-            tyzSum = add_intrin(mul_intrin(tyzSum, facv7), load_intrin<Vec_t>(&trg_value[5][t]));
-
-            tzxSum = add_intrin(mul_intrin(tzxSum, facv7), load_intrin<Vec_t>(&trg_value[6][t]));
-            tzySum = add_intrin(mul_intrin(tzySum, facv7), load_intrin<Vec_t>(&trg_value[7][t]));
-            tzzSum = add_intrin(mul_intrin(tzzSum, facv7), load_intrin<Vec_t>(&trg_value[8][t]));
-
-            store_intrin(&trg_value[0][t], txxSum);
-            store_intrin(&trg_value[1][t], txySum);
-            store_intrin(&trg_value[2][t], txzSum);
-
-            store_intrin(&trg_value[3][t], tyxSum);
-            store_intrin(&trg_value[4][t], tyySum);
-            store_intrin(&trg_value[5][t], tyzSum);
-
-            store_intrin(&trg_value[6][t], tzxSum);
-            store_intrin(&trg_value[7][t], tzySum);
-            store_intrin(&trg_value[8][t], tzzSum);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_doubletraction, stokes_doubletraction_uKernel, 9, 9)
-
 } // namespace pvfmm
 #endif

--- a/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
@@ -55,6 +55,89 @@ struct stokes_doublepvel_new : public GenericKernel<stokes_doublepvel_new> {
 };
 
 
+struct stokes_doublepvelgrad_new : public GenericKernel<stokes_doublepvelgrad_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[16], const VecType (&r)[3], const VecType (&f)[9], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv2 = rinv * rinv;
+        VecType rinv3 = rinv * rinv2;
+        VecType rinv5 = rinv3 * rinv2;
+        VecType rinv7 = rinv5 * rinv2;
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType five = (typename VecType::ScalarType)(5.0);
+        // clang-format off
+        const VecType sxx = f[0], sxy = f[1], sxz = f[2];
+        const VecType syx = f[3], syy = f[4], syz = f[5];
+        const VecType szx = f[6], szy = f[7], szz = f[8];
+        const VecType dx  = r[0], dy  = r[1], dz  = r[2];
+        // clang-format on
+
+        VecType commonCoeff = sxx * dx * dx + syy * dy * dy + szz * dz * dz;
+        commonCoeff += (sxy + syx) * dx * dy;
+        commonCoeff += (sxz + szx) * dx * dz;
+        commonCoeff += (syz + szy) * dy * dz;
+        VecType commonCoeffn3 = (typename VecType::ScalarType)(-3.0) * commonCoeff;
+        VecType commonCoeff5 = (typename VecType::ScalarType)(5.0) * commonCoeff;
+
+        const VecType trace = sxx + syy + szz;
+
+
+        VecType rksxk = dx * sxx + dy * sxy + dz * sxz;
+        VecType rksyk = dx * syx + dy * syy + dz * syz;
+        VecType rkszk = dx * szx + dy * szy + dz * szz;
+
+        VecType rkskx = dx * sxx + dy * syx + dz * szx;
+        VecType rksky = dx * sxy + dy * syy + dz * szy;
+        VecType rkskz = dx * sxz + dy * syz + dz * szz;
+
+        // pressure terms pick up an extra factor of two
+        u[0] += two * (commonCoeffn3 + r2 * trace) * rinv5; // p
+
+        // velocity
+        u[1] += rinv5 * dx * commonCoeffn3;
+        u[2] += rinv5 * dy * commonCoeffn3;
+        u[3] += rinv5 * dz * commonCoeffn3;
+
+        // All r7 terms pick up a factor of -3.0
+        // pressure terms an extra two
+        rinv7 *= -three;
+        u[4] -= two * rinv7 * (dx * commonCoeff5 - r2 * ((rksxk + rkskx) + dx * trace));
+        u[5] -= two * rinv7 * (dy * commonCoeff5 - r2 * ((rksyk + rksky) + dy * trace));
+        u[6] -= two * rinv7 * (dz * commonCoeff5 - r2 * ((rkszk + rkskz) + dz * trace));
+
+        // vgrad
+        VecType commonCoeffn1 = -commonCoeff;
+        // (-2*(t0 - s0)*sv0 - (t1 - s1)*(sv1 + sv3) - (t2 - s2)*(sv2 + sv6))
+        VecType dcFd0 = -two * dx * sxx - dy * (sxy + syx) - dz * (sxz + szx);
+
+        // (-2*(t1 - s1)*sv4 - (t0 - s0)*(sv1 + sv3) - (t2 - s2)*(sv5 + sv7))
+        VecType dcFd1 = -two * dy * syy - dx * (sxy + syx) - dz * (syz + szy);
+
+        // (-2*(t2 - s2)*sv8 - (t0 - s0)*(sv2 + sv6) - (t1 - s1)*(sv5 + sv7))
+        VecType dcFd2 = -two * dz * szz - dx * (sxz + szx) - dy * (syz + szy);
+
+        u[7] += (five * commonCoeffn1 * dx * dx - r2 * dx * dcFd0 - r2 * commonCoeffn1) * rinv7;
+        u[8] += (five * commonCoeffn1 * dx * dy - r2 * dx * dcFd1) * rinv7;
+        u[9] += (five * commonCoeffn1 * dx * dz - r2 * dx * dcFd2) * rinv7;
+
+        u[10] += (five * commonCoeffn1 * dy * dx - r2 * dy * dcFd0) * rinv7;
+        u[11] += (five * commonCoeffn1 * dy * dy - r2 * dy * dcFd1 - r2 * commonCoeffn1) * rinv7;
+        u[12] += (five * commonCoeffn1 * dy * dz - r2 * dy * dcFd2) * rinv7;
+
+        u[13] += (five * commonCoeffn1 * dz * dx - r2 * dz * dcFd0) * rinv7;
+        u[14] += (five * commonCoeffn1 * dz * dy - r2 * dz * dcFd1) * rinv7;
+        u[15] += (five * commonCoeffn1 * dz * dz - r2 * dz * dcFd2 - r2 * commonCoeffn1) * rinv7;
+    }
+};
+
+
 /*********************************************************
  *                                                        *
  *   Stokes Double P Vel kernel, source: 9, target: 4     *

--- a/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesDoubleLayerKernel.hpp
@@ -19,6 +19,42 @@
 
 namespace pvfmm {
 
+
+struct stokes_doublepvel_new : public GenericKernel<stokes_doublepvel_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[4], const VecType (&r)[3], const VecType (&f)[9], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        VecType rinv5 = rinv3 * rinv * rinv;
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        // clang-format off
+        const VecType sxx = f[0], sxy = f[1], sxz = f[2];
+        const VecType syx = f[3], syy = f[4], syz = f[5];
+        const VecType szx = f[6], szy = f[7], szz = f[8];
+        const VecType dx  = r[0], dy  = r[1], dz  = r[2];
+        // clang-format on
+
+        VecType commonCoeff = sxx * dx * dx + syy * dy * dy + szz * dz * dz;
+        commonCoeff += (sxy + syx) * dx * dy;
+        commonCoeff += (sxz + szx) * dx * dz;
+        commonCoeff += (syz + szy) * dy * dz;
+        commonCoeff *= (typename VecType::ScalarType)(-3.0) * rinv5;
+
+        const VecType trace = sxx + syy + szz;
+        u[0] += two * (commonCoeff + r2 * rinv5 * trace);
+        u[1] += dx * commonCoeff;
+        u[2] += dy * commonCoeff;
+        u[3] += dz * commonCoeff;
+    }
+};
+
+
 /*********************************************************
  *                                                        *
  *   Stokes Double P Vel kernel, source: 9, target: 4     *

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -45,7 +45,7 @@ struct StokesLayerKernel {
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
-    static Kernel<T> ker = BuildKernel<T, stokes_vel<T, NEWTON_ITE>>("stokes_vel", 3, std::pair<int, int>(3, 3));
+    static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));
     return ker;
 }
 

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -84,7 +84,6 @@ inline const Kernel<T> &StokesLayerKernelNew<T>::PVelGrad() {
     return stokes_pgker;
 }
 
-
 template <class T>
 inline const Kernel<T> &StokesLayerKernelNew<T>::PVelLaplacian() {
     static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
@@ -98,6 +97,18 @@ inline const Kernel<T> &StokesLayerKernelNew<T>::PVelLaplacian() {
     return stokes_pgker;
 }
 
+template <class T>
+inline const Kernel<T> &StokesLayerKernelNew<T>::Traction() {
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
+        "stokes_PVel", 3, std::pair<int, int>(4, 4));
+    stokes_pker.surf_dim = 9;
+    static Kernel<T> stokes_pgker =
+        BuildKernel<T, stokes_traction_new::Eval<T>, stokes_doubletraction_new::Eval<T>>(
+            "stokes_Traction", 3, std::pair<int, int>(4, 9), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
+            &stokes_pker, NULL, &stokes_pker, NULL);
+    stokes_pgker.surf_dim = 9;
+    return stokes_pgker;
+}
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -32,83 +32,8 @@ struct StokesLayerKernel {
     inline static const Kernel<T> &PVelGrad();      ///< SL+DL -> PVelGrad
     inline static const Kernel<T> &PVelLaplacian(); ///< SL+DL -> PVelLaplacian
     inline static const Kernel<T> &Traction();      ///< SL+DL -> Traction
-
-  private:
-    /**
-     * @brief number of Newton iteration times
-     *  generate NEWTON_ITE at compile time.
-     * 1 for float and 2 for double
-     *
-     */
-    static constexpr int NEWTON_ITE = sizeof(T) / 4;
 };
 
-
-/**
- * @brief Stokes Layer Kernels
- *
- * @tparam T float or double
- */
-template <class T>
-struct StokesLayerKernelNew {
-    inline static const Kernel<T> &Vel();           ///< Stokeslet 3x3, SL->Vel
-    inline static const Kernel<T> &PVel();          ///< SL+DL -> PVel
-    inline static const Kernel<T> &PVelGrad();      ///< SL+DL -> PVelGrad
-    inline static const Kernel<T> &PVelLaplacian(); ///< SL+DL -> PVelLaplacian
-    inline static const Kernel<T> &Traction();      ///< SL+DL -> Traction
-};
-
-template <class T>
-inline const Kernel<T> &StokesLayerKernelNew<T>::Vel() {
-    static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));
-    return ker;
-}
-
-template <class T>
-inline const Kernel<T> &StokesLayerKernelNew<T>::PVel() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
-        "stokes_PVel", 3, std::pair<int, int>(4, 4));
-    stokes_pker.surf_dim = 9;
-    return stokes_pker;
-}
-
-template <class T>
-inline const Kernel<T> &StokesLayerKernelNew<T>::PVelGrad() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
-        "stokes_PVel", 3, std::pair<int, int>(4, 4));
-    stokes_pker.surf_dim = 9;
-    static Kernel<T> stokes_pgker = BuildKernel<T, stokes_pvelgrad_new::Eval<T>, stokes_doublepvelgrad_new::Eval<T>>(
-        "stokes_PVelGrad", 3, std::pair<int, int>(4, 16), &stokes_pker, &stokes_pker, NULL, &stokes_pker, &stokes_pker,
-        NULL, &stokes_pker, NULL);
-    stokes_pgker.surf_dim = 9;
-    return stokes_pgker;
-}
-
-template <class T>
-inline const Kernel<T> &StokesLayerKernelNew<T>::PVelLaplacian() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
-        "stokes_PVel", 3, std::pair<int, int>(4, 4));
-    stokes_pker.surf_dim = 9;
-    static Kernel<T> stokes_pgker =
-        BuildKernel<T, stokes_pvellaplacian_new::Eval<T>, stokes_doublelaplacian_new::Eval<T>>(
-            "stokes_PVelLaplacian", 3, std::pair<int, int>(4, 7), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
-            &stokes_pker, NULL, &stokes_pker, NULL);
-    stokes_pgker.surf_dim = 9;
-    return stokes_pgker;
-}
-
-template <class T>
-inline const Kernel<T> &StokesLayerKernelNew<T>::Traction() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
-        "stokes_PVel", 3, std::pair<int, int>(4, 4));
-    stokes_pker.surf_dim = 9;
-    static Kernel<T> stokes_pgker =
-        BuildKernel<T, stokes_traction_new::Eval<T>, stokes_doubletraction_new::Eval<T>>(
-            "stokes_Traction", 3, std::pair<int, int>(4, 9), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
-            &stokes_pker, NULL, &stokes_pker, NULL);
-    stokes_pgker.surf_dim = 9;
-    return stokes_pgker;
-}
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
@@ -118,7 +43,7 @@ inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::PVel() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel<T, NEWTON_ITE>, stokes_doublepvel<T, NEWTON_ITE>>(
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel::Eval<T>, stokes_doublepvel::Eval<T>>(
         "stokes_PVel", 3, std::pair<int, int>(4, 4));
     stokes_pker.surf_dim = 9;
     return stokes_pker;
@@ -126,24 +51,23 @@ inline const Kernel<T> &StokesLayerKernel<T>::PVel() {
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::PVelGrad() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel<T, NEWTON_ITE>, stokes_doublepvel<T, NEWTON_ITE>>(
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel::Eval<T>, stokes_doublepvel::Eval<T>>(
         "stokes_PVel", 3, std::pair<int, int>(4, 4));
     stokes_pker.surf_dim = 9;
-    static Kernel<T> stokes_pgker =
-        BuildKernel<T, stokes_pvelgrad<T, NEWTON_ITE>, stokes_doublepvelgrad<T, NEWTON_ITE>>(
-            "stokes_PVelGrad", 3, std::pair<int, int>(4, 16), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
-            &stokes_pker, NULL, &stokes_pker, NULL);
+    static Kernel<T> stokes_pgker = BuildKernel<T, stokes_pvelgrad::Eval<T>, stokes_doublepvelgrad::Eval<T>>(
+        "stokes_PVelGrad", 3, std::pair<int, int>(4, 16), &stokes_pker, &stokes_pker, NULL, &stokes_pker, &stokes_pker,
+        NULL, &stokes_pker, NULL);
     stokes_pgker.surf_dim = 9;
     return stokes_pgker;
 }
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::PVelLaplacian() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel<T, NEWTON_ITE>, stokes_doublepvel<T, NEWTON_ITE>>(
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel::Eval<T>, stokes_doublepvel::Eval<T>>(
         "stokes_PVel", 3, std::pair<int, int>(4, 4));
     stokes_pker.surf_dim = 9;
     static Kernel<T> stokes_pgker =
-        BuildKernel<T, stokes_pvellaplacian<T, NEWTON_ITE>, stokes_doublelaplacian<T, NEWTON_ITE>>(
+        BuildKernel<T, stokes_pvellaplacian::Eval<T>, stokes_doublelaplacian::Eval<T>>(
             "stokes_PVelLaplacian", 3, std::pair<int, int>(4, 7), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
             &stokes_pker, NULL, &stokes_pker, NULL);
     stokes_pgker.surf_dim = 9;
@@ -152,11 +76,11 @@ inline const Kernel<T> &StokesLayerKernel<T>::PVelLaplacian() {
 
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Traction() {
-    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel<T, NEWTON_ITE>, stokes_doublepvel<T, NEWTON_ITE>>(
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel::Eval<T>, stokes_doublepvel::Eval<T>>(
         "stokes_PVel", 3, std::pair<int, int>(4, 4));
     stokes_pker.surf_dim = 9;
     static Kernel<T> stokes_pgker =
-        BuildKernel<T, stokes_traction<T, NEWTON_ITE>, stokes_doubletraction<T, NEWTON_ITE>>(
+        BuildKernel<T, stokes_traction::Eval<T>, stokes_doubletraction::Eval<T>>(
             "stokes_Traction", 3, std::pair<int, int>(4, 9), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
             &stokes_pker, NULL, &stokes_pker, NULL);
     stokes_pgker.surf_dim = 9;

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -84,6 +84,21 @@ inline const Kernel<T> &StokesLayerKernelNew<T>::PVelGrad() {
     return stokes_pgker;
 }
 
+
+template <class T>
+inline const Kernel<T> &StokesLayerKernelNew<T>::PVelLaplacian() {
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
+        "stokes_PVel", 3, std::pair<int, int>(4, 4));
+    stokes_pker.surf_dim = 9;
+    static Kernel<T> stokes_pgker =
+        BuildKernel<T, stokes_pvellaplacian_new::Eval<T>, stokes_doublelaplacian_new::Eval<T>>(
+            "stokes_PVelLaplacian", 3, std::pair<int, int>(4, 7), &stokes_pker, &stokes_pker, NULL, &stokes_pker,
+            &stokes_pker, NULL, &stokes_pker, NULL);
+    stokes_pgker.surf_dim = 9;
+    return stokes_pgker;
+}
+
+
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
     static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -73,6 +73,18 @@ inline const Kernel<T> &StokesLayerKernelNew<T>::PVel() {
 }
 
 template <class T>
+inline const Kernel<T> &StokesLayerKernelNew<T>::PVelGrad() {
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
+        "stokes_PVel", 3, std::pair<int, int>(4, 4));
+    stokes_pker.surf_dim = 9;
+    static Kernel<T> stokes_pgker = BuildKernel<T, stokes_pvelgrad_new::Eval<T>, stokes_doublepvelgrad_new::Eval<T>>(
+        "stokes_PVelGrad", 3, std::pair<int, int>(4, 16), &stokes_pker, &stokes_pker, NULL, &stokes_pker, &stokes_pker,
+        NULL, &stokes_pker, NULL);
+    stokes_pgker.surf_dim = 9;
+    return stokes_pgker;
+}
+
+template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
     static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));
     return ker;

--- a/Lib/include/STKFMM/StokesLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesLayerKernel.hpp
@@ -43,6 +43,35 @@ struct StokesLayerKernel {
     static constexpr int NEWTON_ITE = sizeof(T) / 4;
 };
 
+
+/**
+ * @brief Stokes Layer Kernels
+ *
+ * @tparam T float or double
+ */
+template <class T>
+struct StokesLayerKernelNew {
+    inline static const Kernel<T> &Vel();           ///< Stokeslet 3x3, SL->Vel
+    inline static const Kernel<T> &PVel();          ///< SL+DL -> PVel
+    inline static const Kernel<T> &PVelGrad();      ///< SL+DL -> PVelGrad
+    inline static const Kernel<T> &PVelLaplacian(); ///< SL+DL -> PVelLaplacian
+    inline static const Kernel<T> &Traction();      ///< SL+DL -> Traction
+};
+
+template <class T>
+inline const Kernel<T> &StokesLayerKernelNew<T>::Vel() {
+    static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));
+    return ker;
+}
+
+template <class T>
+inline const Kernel<T> &StokesLayerKernelNew<T>::PVel() {
+    static Kernel<T> stokes_pker = BuildKernel<T, stokes_pvel_new::Eval<T>, stokes_doublepvel_new::Eval<T>>(
+        "stokes_PVel", 3, std::pair<int, int>(4, 4));
+    stokes_pker.surf_dim = 9;
+    return stokes_pker;
+}
+
 template <class T>
 inline const Kernel<T> &StokesLayerKernel<T>::Vel() {
     static Kernel<T> ker = BuildKernel<T, stokes_vel::Eval<T>>("stokes_vel", 3, std::pair<int, int>(3, 3));

--- a/Lib/include/STKFMM/StokesRegSingleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesRegSingleLayerKernel.hpp
@@ -9,6 +9,187 @@
 
 namespace pvfmm {
 
+
+struct stokes_regvel_new : public GenericKernel<stokes_regvel_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[3], const VecType (&r)[3], const VecType (&f)[4], const void *ctx_ptr) {
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &reg = f[3];
+        // clang-format on
+        VecType r2 = dx * dx + dy * dy + dz * dz + reg * reg;
+
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        VecType r2reg2 = r2 + reg * reg;
+
+        VecType commonCoeff = fx * dx + fy * dy + fz * dz;
+        u[0] += rinv3 * (r2reg2 * fx + dx * commonCoeff);
+        u[1] += rinv3 * (r2reg2 * fy + dy * commonCoeff);
+        u[2] += rinv3 * (r2reg2 * fz + dz * commonCoeff);
+    }
+};
+
+struct stokes_regftvel_new : public GenericKernel<stokes_regftvel_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[3], const VecType (&r)[3], const VecType (&f)[7], const void *ctx_ptr) {
+        const VecType half = (typename VecType::ScalarType)(0.5);
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType five = (typename VecType::ScalarType)(5.0);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &tx = f[3], &ty = f[4], &tz = f[5];
+        const VecType &eps = f[6];
+        // clang-format on
+        VecType eps2 = eps * eps;
+
+        VecType r2 = dx * dx + dy * dy + dz * dz;
+        VecType denom_arg = r2 + eps2;
+        VecType rinv = sctl::approx_rsqrt<digits>(denom_arg);
+
+        VecType stokeslet_denom_inv = rinv * rinv * rinv;
+        VecType rotlet_denom_inv = half * stokeslet_denom_inv * rinv * rinv;
+        VecType rotlet_coef = (two * r2 + five * eps2) * rotlet_denom_inv;
+        VecType H2 = stokeslet_denom_inv;
+        VecType H1 = (r2 + two * eps2) * H2;
+
+        VecType tcurlrx = ty * dz - tz * dy;
+        VecType tcurlry = tz * dx - tx * dz;
+        VecType tcurlrz = tx * dy - ty * dx;
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+        VecType tdotr = tx * dx + ty * dy + tz * dz;
+
+        u[0] += H1 * fx + H2 * fdotr * dx + rotlet_coef * tcurlrx;
+        u[1] += H1 * fy + H2 * fdotr * dy + rotlet_coef * tcurlry;
+        u[2] += H1 * fz + H2 * fdotr * dz + rotlet_coef * tcurlrz;
+    }
+};
+
+struct stokes_regftvelomega_new : public GenericKernel<stokes_regftvelomega_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[6], const VecType (&r)[3], const VecType (&f)[7], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        const VecType half = (typename VecType::ScalarType)(0.5);
+        const VecType two = (typename VecType::ScalarType)(2.0);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType five = (typename VecType::ScalarType)(5.0);
+        const VecType seven = (typename VecType::ScalarType)(7.0);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &tx = f[3], &ty = f[4], &tz = f[5];
+        const VecType &eps = f[6];
+        // clang-format on
+        VecType r4 = r2 * r2;
+        VecType eps2 = eps * eps;
+        VecType eps4 = eps2 * eps2;
+
+        VecType rinv = sctl::approx_rsqrt<digits>(eps2 + r2);
+
+        const VecType stokeslet_denom_inv = rinv * rinv *rinv;
+        VecType rotlet_denom_inv = half * stokeslet_denom_inv * rinv * rinv;
+        VecType dipole_denom_inv = half * rotlet_denom_inv * rinv * rinv;
+        VecType rotlet_coef = (two * r2 + five * eps2) * rotlet_denom_inv;
+        VecType D1 = (two * five * eps4 - seven * eps2 * r2 - two * r4) * dipole_denom_inv;
+        VecType D2 = (seven * three * eps2 + two * three * r2) * dipole_denom_inv;
+        const VecType &H2 = stokeslet_denom_inv;
+        VecType H1 = (r2 + two * eps2) * H2;
+
+        VecType fcurlrx = fy * dz - fz * dy;
+        VecType fcurlry = fz * dx - fx * dz;
+        VecType fcurlrz = fx * dy - fy * dx;
+
+        VecType tcurlrx = ty * dz - tz * dy;
+        VecType tcurlry = tz * dx - tx * dz;
+        VecType tcurlrz = tx * dy - ty * dx;
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+        VecType tdotr = tx * dx + ty * dy + tz * dz;
+
+        u[0] += H1 * fx + H2 * fdotr * dx + rotlet_coef * tcurlrx;
+        u[1] += H1 * fy + H2 * fdotr * dy + rotlet_coef * tcurlry;
+        u[2] += H1 * fz + H2 * fdotr * dz + rotlet_coef * tcurlrz;
+
+        u[3] += D1 * tx + D2 * tdotr * dx + rotlet_coef * fcurlrx;
+        u[4] += D1 * ty + D2 * tdotr * dy + rotlet_coef * fcurlry;
+        u[5] += D1 * tz + D2 * tdotr * dz + rotlet_coef * fcurlrz;
+    }
+};
+
+struct stokes_velomega_new : public GenericKernel<stokes_velomega_new> {
+    static const int FLOPS = 20;
+    template <class Real>
+    static Real ScaleFactor() {
+        return 1.0 / (8.0 * const_pi<Real>());
+    }
+    template <class VecType, int digits>
+    static void uKerEval(VecType (&u)[6], const VecType (&r)[3], const VecType (&f)[3], const void *ctx_ptr) {
+        VecType r2 = r[0] * r[0] + r[1] * r[1] + r[2] * r[2];
+        VecType rinv = sctl::approx_rsqrt<digits>(r2, r2 > VecType::Zero());
+        VecType rinv3 = rinv * rinv * rinv;
+        const VecType half = (typename VecType::ScalarType)(0.5);
+        const VecType three = (typename VecType::ScalarType)(3.0);
+        const VecType one_over_three = (typename VecType::ScalarType)(0.3333333333333);
+
+        // clang-format off
+        const VecType &dx = r[0], &dy = r[1], &dz = r[2];
+        const VecType &fx = f[0], &fy = f[1], &fz = f[2];
+        const VecType &reg = f[3];
+        // clang-format on
+
+        VecType r4 = r2 * r2;
+        const VecType &denom_arg = r2;
+
+        const VecType &stokeslet_denom_inv = rinv3;
+        VecType rotlet_denom_inv = (typename VecType::ScalarType)(0.5) * stokeslet_denom_inv * rinv * rinv;
+        VecType rotlet_coef = (typename VecType::ScalarType)(2.0) * r2 * rotlet_denom_inv;
+        VecType H2 = stokeslet_denom_inv;
+        VecType H1 = r2 * H2;
+
+        VecType fcurlrx = fy * dz - fz * dy;
+        VecType fcurlry = fz * dx - fx * dz;
+        VecType fcurlrz = fx * dy - fy * dx;
+
+        VecType fdotr = fx * dx + fy * dy + fz * dz;
+
+        u[0] += H1 * fx + H2 * fdotr * dx;
+        u[1] += H1 * fy + H2 * fdotr * dy;
+        u[2] += H1 * fz + H2 * fdotr * dz;
+
+        u[3] += rotlet_coef * fcurlrx;
+        u[4] += rotlet_coef * fcurlry;
+        u[5] += rotlet_coef * fcurlrz;
+    }
+};
+
+
+template <class T>
+struct StokesRegKernelNew {
+    inline static const Kernel<T> &Vel();        //   3+1->3
+    inline static const Kernel<T> &FTVelOmega(); //   3+3+1->3+3
+};
+
+
 /*********************************************************
  *                                                        *
  *     Stokes Reg Vel kernel, source: 4, target: 3        *
@@ -431,6 +612,31 @@ inline const Kernel<T> &StokesRegKernel<T>::FTVelOmega() {
 
     return s2t_ker;
 }
+
+template <class T>
+inline const Kernel<T> &StokesRegKernelNew<T>::Vel() {
+    static Kernel<T> stk_ker = StokesKernel<T>::velocity();
+    static Kernel<T> s2t_ker =
+        BuildKernel<T, stokes_regvel_new::Eval<T>>("stokes_regvel", 3, std::pair<int, int>(4, 3), NULL, NULL, NULL,
+                                                     &stk_ker, &stk_ker, &stk_ker, &stk_ker, &stk_ker, NULL, true);
+
+    return s2t_ker;
+}
+
+template <class T>
+inline const Kernel<T> &StokesRegKernelNew<T>::FTVelOmega() {
+    static Kernel<T> stk_ker = StokesKernel<T>::velocity();
+    static Kernel<T> stk_velomega =
+        BuildKernel<T, stokes_velomega_new::Eval<T>>("stokes_velomega", 3, std::pair<int, int>(3, 6));
+    static Kernel<T> stk_regftvel =
+        BuildKernel<T, stokes_regftvel_new::Eval<T>>("stokes_regftvel", 3, std::pair<int, int>(7, 3));
+    static Kernel<T> s2t_ker = BuildKernel<T, stokes_regftvelomega_new::Eval<T>>(
+        "stokes_regftvelomega", 3, std::pair<int, int>(7, 6), &stk_regftvel, &stk_regftvel, NULL, &stk_ker, &stk_ker,
+        &stk_velomega, &stk_ker, &stk_velomega);
+
+    return s2t_ker;
+}
+
 
 } // namespace pvfmm
 #endif // STOKESSINGLELAYERKERNEL_HPP

--- a/Lib/include/STKFMM/StokesRegSingleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesRegSingleLayerKernel.hpp
@@ -9,8 +9,12 @@
 
 namespace pvfmm {
 
-
-struct stokes_regvel_new : public GenericKernel<stokes_regvel_new> {
+/*********************************************************
+ *                                                        *
+ *     Stokes Reg Vel kernel, source: 4, target: 3        *
+ *              fx,fy,fz,eps -> ux,uy,uz                  *
+ **********************************************************/
+struct stokes_regvel : public GenericKernel<stokes_regvel> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -36,7 +40,12 @@ struct stokes_regvel_new : public GenericKernel<stokes_regvel_new> {
     }
 };
 
-struct stokes_regftvel_new : public GenericKernel<stokes_regftvel_new> {
+/**********************************************************
+ *                                                        *
+ * Stokes Reg Force Torque Vel kernel,source: 7, target: 3*
+ *       fx,fy,fz,tx,ty,tz,eps -> ux,uy,uz                *
+ **********************************************************/
+struct stokes_regftvel : public GenericKernel<stokes_regftvel> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -79,7 +88,12 @@ struct stokes_regftvel_new : public GenericKernel<stokes_regftvel_new> {
     }
 };
 
-struct stokes_regftvelomega_new : public GenericKernel<stokes_regftvelomega_new> {
+/****************************************************************
+ *                                                              *
+ *Stokes Reg Force Torque Vel Omega kernel, source: 7, target: 6*
+ *    fx,fy,fz,tx,ty,tz,eps -> ux,uy,uz,wx,wy,wz                *
+ ****************************************************************/
+struct stokes_regftvelomega : public GenericKernel<stokes_regftvelomega> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -106,7 +120,7 @@ struct stokes_regftvelomega_new : public GenericKernel<stokes_regftvelomega_new>
 
         VecType rinv = sctl::approx_rsqrt<digits>(eps2 + r2);
 
-        const VecType stokeslet_denom_inv = rinv * rinv *rinv;
+        const VecType stokeslet_denom_inv = rinv * rinv * rinv;
         VecType rotlet_denom_inv = half * stokeslet_denom_inv * rinv * rinv;
         VecType dipole_denom_inv = half * rotlet_denom_inv * rinv * rinv;
         VecType rotlet_coef = (two * r2 + five * eps2) * rotlet_denom_inv;
@@ -136,7 +150,12 @@ struct stokes_regftvelomega_new : public GenericKernel<stokes_regftvelomega_new>
     }
 };
 
-struct stokes_velomega_new : public GenericKernel<stokes_velomega_new> {
+/**********************************************************
+ *                                                         *
+ *   Stokes Force Vel Omega kernel, source: 3, target: 6   *
+ *           fx,fy,fz -> ux,uy,uz, wx,wy,wz                *
+ **********************************************************/
+struct stokes_velomega : public GenericKernel<stokes_velomega> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -182,419 +201,18 @@ struct stokes_velomega_new : public GenericKernel<stokes_velomega_new> {
     }
 };
 
-
-template <class T>
-struct StokesRegKernelNew {
-    inline static const Kernel<T> &Vel();        //   3+1->3
-    inline static const Kernel<T> &FTVelOmega(); //   3+3+1->3+3
-};
-
-
-/*********************************************************
- *                                                        *
- *     Stokes Reg Vel kernel, source: 4, target: 3        *
- *              fx,fy,fz,eps -> ux,uy,uz                  *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_regvel_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                           Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t trgx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t trgy = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t trgz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>(); // vx
-            Vec_t vy = zero_intrin<Vec_t>(); // vy
-            Vec_t vz = zero_intrin<Vec_t>(); // vz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(trgx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(trgy, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(trgz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t reg = bcast_intrin<Vec_t>(&src_value[3][s]); // reg parameter
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-                r2 = add_intrin(r2, mul_intrin(reg, reg)); // r^2+eps^2
-
-                Vec_t r2reg2 = add_intrin(r2, mul_intrin(reg, reg)); // r^2 + 2 eps^2
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-
-                Vec_t commonCoeff = mul_intrin(fx, dx);
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fy, dy));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fz, dz));
-
-                vx = add_intrin(vx, mul_intrin(add_intrin(mul_intrin(r2reg2, fx), mul_intrin(dx, commonCoeff)), rinv3));
-                vy = add_intrin(vy, mul_intrin(add_intrin(mul_intrin(r2reg2, fy), mul_intrin(dy, commonCoeff)), rinv3));
-                vz = add_intrin(vz, mul_intrin(add_intrin(mul_intrin(r2reg2, fz), mul_intrin(dz, commonCoeff)), rinv3));
-            }
-
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                        *
- * Stokes Reg Force Torque Vel kernel,source: 7, target: 3*
- *       fx,fy,fz,tx,ty,tz,eps -> ux,uy,uz                *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_regftvel_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                             Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facnwtn = set_intrin<Vec_t, Real_t>(1 / (nwtn_scal));
-
-    const Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    const Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-    const Vec_t seven = set_intrin<Vec_t, Real_t>(7.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t trgx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t trgy = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t trgz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>(); // vx
-            Vec_t vy = zero_intrin<Vec_t>(); // vy
-            Vec_t vz = zero_intrin<Vec_t>(); // vz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(trgx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(trgy, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(trgz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t tx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                const Vec_t ty = bcast_intrin<Vec_t>(&src_value[4][s]);
-                const Vec_t tz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                const Vec_t eps = bcast_intrin<Vec_t>(&src_value[6][s]); // reg parameter
-
-                // length squared of r
-                Vec_t r2 = dx * dx + dy * dy + dz * dz;
-                Vec_t r4 = r2 * r2;
-
-                // regularization parameter squared
-                Vec_t eps2 = eps * eps;
-                Vec_t eps4 = eps2 * eps2;
-
-                Vec_t denom_arg = eps2 + r2;
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(denom_arg);
-                rinv = rinv * facnwtn;
-
-                Vec_t stokeslet_denom_inv = rinv * rinv * rinv;
-                Vec_t rotlet_denom_inv = set_intrin<Vec_t, Real_t>(0.5) * stokeslet_denom_inv * rinv * rinv;
-                Vec_t rotlet_coef = (two * r2 + five * eps2) * rotlet_denom_inv;
-                Vec_t H2 = stokeslet_denom_inv;
-                Vec_t H1 = (r2 + two * eps2) * H2;
-
-                Vec_t tcurlrx = ty * dz - tz * dy;
-                Vec_t tcurlry = tz * dx - tx * dz;
-                Vec_t tcurlrz = tx * dy - ty * dx;
-
-                Vec_t fdotr = fx * dx + fy * dy + fz * dz;
-                Vec_t tdotr = tx * dx + ty * dy + tz * dz;
-
-                vx += H1 * fx + H2 * fdotr * dx + rotlet_coef * tcurlrx;
-                vy += H1 * fy + H2 * fdotr * dy + rotlet_coef * tcurlry;
-                vz += H1 * fz + H2 * fdotr * dz + rotlet_coef * tcurlrz;
-            }
-
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                        *
- *Stokes Reg Force Torque Vel Omega kernel, source: 7, target: 6*
- *    fx,fy,fz,tx,ty,tz,eps -> ux,uy,uz,wx,wy,wz         *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_regftvelomega_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                  Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facnwtn = set_intrin<Vec_t, Real_t>(1 / (nwtn_scal));
-
-    const Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    const Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-    const Vec_t seven = set_intrin<Vec_t, Real_t>(7.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t trgx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t trgy = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t trgz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>(); // vx
-            Vec_t vy = zero_intrin<Vec_t>(); // vy
-            Vec_t vz = zero_intrin<Vec_t>(); // vz
-            Vec_t wx = zero_intrin<Vec_t>(); // wx
-            Vec_t wy = zero_intrin<Vec_t>(); // wy
-            Vec_t wz = zero_intrin<Vec_t>(); // wz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(trgx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(trgy, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(trgz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t tx = bcast_intrin<Vec_t>(&src_value[3][s]);
-                const Vec_t ty = bcast_intrin<Vec_t>(&src_value[4][s]);
-                const Vec_t tz = bcast_intrin<Vec_t>(&src_value[5][s]);
-                const Vec_t eps = bcast_intrin<Vec_t>(&src_value[6][s]); // reg parameter
-
-                // length squared of r
-                Vec_t r2 = dx * dx + dy * dy + dz * dz;
-                Vec_t r4 = r2 * r2;
-
-                // regularization parameter squared
-                Vec_t eps2 = eps * eps;
-                Vec_t eps4 = eps2 * eps2;
-
-                Vec_t denom_arg = eps2 + r2;
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(denom_arg);
-                rinv = rinv * facnwtn;
-
-                // Vec_t stokeslet_denom = pi8 * denom_arg * std::sqrt(denom_arg);
-                // Vec_t rotlet_denom = 2 * stokeslet_denom * denom_arg;
-                // Vec_t dipole_denom = 2 * rotlet_denom * denom_arg;
-                // Vec_t rotlet_coef = (2 * r2 + 5.0 * eps2) / rotlet_denom;
-                // Vec_t D1 = (10 * eps4 - 7 * eps2 * r2 - 2 * r4) / dipole_denom;
-                // Vec_t D2 = (21 * eps2 + 6 * r2) / dipole_denom;
-                // Vec_t H2 = 1.0 / stokeslet_denom;
-                // Vec_t H1 = (r2 + 2.0 * eps2) * H2;
-                Vec_t stokeslet_denom_inv = rinv * rinv * rinv;
-                Vec_t rotlet_denom_inv = set_intrin<Vec_t, Real_t>(0.5) * stokeslet_denom_inv * rinv * rinv;
-                Vec_t dipole_denom_inv = set_intrin<Vec_t, Real_t>(0.5) * rotlet_denom_inv * rinv * rinv;
-                Vec_t rotlet_coef = (two * r2 + five * eps2) * rotlet_denom_inv;
-                Vec_t D1 = (two * five * eps4 - seven * eps2 * r2 - two * r4) * dipole_denom_inv;
-                Vec_t D2 = (seven * three * eps2 + two * three * r2) * dipole_denom_inv;
-                Vec_t H2 = stokeslet_denom_inv;
-                Vec_t H1 = (r2 + two * eps2) * H2;
-
-                Vec_t fcurlrx = fy * dz - fz * dy;
-                Vec_t fcurlry = fz * dx - fx * dz;
-                Vec_t fcurlrz = fx * dy - fy * dx;
-
-                Vec_t tcurlrx = ty * dz - tz * dy;
-                Vec_t tcurlry = tz * dx - tx * dz;
-                Vec_t tcurlrz = tx * dy - ty * dx;
-
-                Vec_t fdotr = fx * dx + fy * dy + fz * dz;
-                Vec_t tdotr = tx * dx + ty * dy + tz * dz;
-
-                vx += H1 * fx + H2 * fdotr * dx + rotlet_coef * tcurlrx;
-                vy += H1 * fy + H2 * fdotr * dy + rotlet_coef * tcurlry;
-                vz += H1 * fz + H2 * fdotr * dz + rotlet_coef * tcurlrz;
-
-                wx += D1 * tx + D2 * tdotr * dx + rotlet_coef * fcurlrx;
-                wy += D1 * ty + D2 * tdotr * dy + rotlet_coef * fcurlry;
-                wz += D1 * tz + D2 * tdotr * dz + rotlet_coef * fcurlrz;
-            }
-
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            wx = add_intrin(mul_intrin(wx, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-            wy = add_intrin(mul_intrin(wy, facv), load_intrin<Vec_t>(&trg_value[4][t]));
-            wz = add_intrin(mul_intrin(wz, facv), load_intrin<Vec_t>(&trg_value[5][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-            store_intrin(&trg_value[3][t], wx);
-            store_intrin(&trg_value[4][t], wy);
-            store_intrin(&trg_value[5][t], wz);
-        }
-    }
-}
-
-/**********************************************************
- *                                                         *
- *   Stokes Force Vel Omega kernel, source: 3, target: 6   *
- *           fx,fy,fz -> ux,uy,uz, wx,wy,wz                *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_velomega_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                             Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facnwtn = set_intrin<Vec_t, Real_t>(1 / (nwtn_scal));
-
-    const Vec_t two = set_intrin<Vec_t, Real_t>(2.0);
-    const Vec_t three = set_intrin<Vec_t, Real_t>(3.0);
-    const Vec_t five = set_intrin<Vec_t, Real_t>(5.0);
-    const Vec_t seven = set_intrin<Vec_t, Real_t>(7.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t trgx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t trgy = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t trgz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t vx = zero_intrin<Vec_t>(); // vx
-            Vec_t vy = zero_intrin<Vec_t>(); // vy
-            Vec_t vz = zero_intrin<Vec_t>(); // vz
-            Vec_t wx = zero_intrin<Vec_t>(); // wx
-            Vec_t wy = zero_intrin<Vec_t>(); // wy
-            Vec_t wz = zero_intrin<Vec_t>(); // wz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(trgx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(trgy, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(trgz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-
-                // length squared of r
-                Vec_t r2 = dx * dx + dy * dy + dz * dz;
-                Vec_t r4 = r2 * r2;
-
-                Vec_t denom_arg = r2;
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(denom_arg);
-                rinv = rinv * facnwtn;
-
-                Vec_t stokeslet_denom_inv = rinv * rinv * rinv;
-                Vec_t rotlet_denom_inv = set_intrin<Vec_t, Real_t>(0.5) * stokeslet_denom_inv * rinv * rinv;
-                Vec_t rotlet_coef = (two * r2) * rotlet_denom_inv;
-                Vec_t H2 = stokeslet_denom_inv;
-                Vec_t H1 = (r2)*H2;
-
-                Vec_t fcurlrx = fy * dz - fz * dy;
-                Vec_t fcurlry = fz * dx - fx * dz;
-                Vec_t fcurlrz = fx * dy - fy * dx;
-
-                Vec_t fdotr = fx * dx + fy * dy + fz * dz;
-
-                vx += H1 * fx + H2 * fdotr * dx;
-                vy += H1 * fy + H2 * fdotr * dy;
-                vz += H1 * fz + H2 * fdotr * dz;
-
-                wx += rotlet_coef * fcurlrx;
-                wy += rotlet_coef * fcurlry;
-                wz += rotlet_coef * fcurlrz;
-            }
-
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[0][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            wx = add_intrin(mul_intrin(wx, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-            wy = add_intrin(mul_intrin(wy, facv), load_intrin<Vec_t>(&trg_value[4][t]));
-            wz = add_intrin(mul_intrin(wz, facv), load_intrin<Vec_t>(&trg_value[5][t]));
-
-            store_intrin(&trg_value[0][t], vx);
-            store_intrin(&trg_value[1][t], vy);
-            store_intrin(&trg_value[2][t], vz);
-            store_intrin(&trg_value[3][t], wx);
-            store_intrin(&trg_value[4][t], wy);
-            store_intrin(&trg_value[5][t], wz);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_regvel, stokes_regvel_uKernel, 4, 3)
-GEN_KERNEL(stokes_velomega, stokes_velomega_uKernel, 3, 6)
-GEN_KERNEL(stokes_regftvel, stokes_regftvel_uKernel, 7, 3)
-GEN_KERNEL(stokes_regftvelomega, stokes_regftvelomega_uKernel, 7, 6)
-
 template <class T>
 struct StokesRegKernel {
     inline static const Kernel<T> &Vel();        //   3+1->3
     inline static const Kernel<T> &FTVelOmega(); //   3+3+1->3+3
-  private:
-    static constexpr int NEWTON_ITE = sizeof(T) / 4;
 };
 
-// 1 newton for float, 2 newton for double
-// the string for stk_ker must be exactly the same as in kernel.txx of pvfmm
 template <class T>
 inline const Kernel<T> &StokesRegKernel<T>::Vel() {
     static Kernel<T> stk_ker = StokesKernel<T>::velocity();
     static Kernel<T> s2t_ker =
-        BuildKernel<T, stokes_regvel<T, NEWTON_ITE>>("stokes_regvel", 3, std::pair<int, int>(4, 3), NULL, NULL, NULL,
-                                                     &stk_ker, &stk_ker, &stk_ker, &stk_ker, &stk_ker, NULL, true);
+        BuildKernel<T, stokes_regvel::Eval<T>>("stokes_regvel", 3, std::pair<int, int>(4, 3), NULL, NULL, NULL,
+                                               &stk_ker, &stk_ker, &stk_ker, &stk_ker, &stk_ker, NULL, true);
 
     return s2t_ker;
 }
@@ -603,40 +221,15 @@ template <class T>
 inline const Kernel<T> &StokesRegKernel<T>::FTVelOmega() {
     static Kernel<T> stk_ker = StokesKernel<T>::velocity();
     static Kernel<T> stk_velomega =
-        BuildKernel<T, stokes_velomega<T, NEWTON_ITE>>("stokes_velomega", 3, std::pair<int, int>(3, 6));
+        BuildKernel<T, stokes_velomega::Eval<T>>("stokes_velomega", 3, std::pair<int, int>(3, 6));
     static Kernel<T> stk_regftvel =
-        BuildKernel<T, stokes_regftvel<T, NEWTON_ITE>>("stokes_regftvel", 3, std::pair<int, int>(7, 3));
-    static Kernel<T> s2t_ker = BuildKernel<T, stokes_regftvelomega<T, NEWTON_ITE>>(
+        BuildKernel<T, stokes_regftvel::Eval<T>>("stokes_regftvel", 3, std::pair<int, int>(7, 3));
+    static Kernel<T> s2t_ker = BuildKernel<T, stokes_regftvelomega::Eval<T>>(
         "stokes_regftvelomega", 3, std::pair<int, int>(7, 6), &stk_regftvel, &stk_regftvel, NULL, &stk_ker, &stk_ker,
         &stk_velomega, &stk_ker, &stk_velomega);
 
     return s2t_ker;
 }
-
-template <class T>
-inline const Kernel<T> &StokesRegKernelNew<T>::Vel() {
-    static Kernel<T> stk_ker = StokesKernel<T>::velocity();
-    static Kernel<T> s2t_ker =
-        BuildKernel<T, stokes_regvel_new::Eval<T>>("stokes_regvel", 3, std::pair<int, int>(4, 3), NULL, NULL, NULL,
-                                                     &stk_ker, &stk_ker, &stk_ker, &stk_ker, &stk_ker, NULL, true);
-
-    return s2t_ker;
-}
-
-template <class T>
-inline const Kernel<T> &StokesRegKernelNew<T>::FTVelOmega() {
-    static Kernel<T> stk_ker = StokesKernel<T>::velocity();
-    static Kernel<T> stk_velomega =
-        BuildKernel<T, stokes_velomega_new::Eval<T>>("stokes_velomega", 3, std::pair<int, int>(3, 6));
-    static Kernel<T> stk_regftvel =
-        BuildKernel<T, stokes_regftvel_new::Eval<T>>("stokes_regftvel", 3, std::pair<int, int>(7, 3));
-    static Kernel<T> s2t_ker = BuildKernel<T, stokes_regftvelomega_new::Eval<T>>(
-        "stokes_regftvelomega", 3, std::pair<int, int>(7, 6), &stk_regftvel, &stk_regftvel, NULL, &stk_ker, &stk_ker,
-        &stk_velomega, &stk_ker, &stk_velomega);
-
-    return s2t_ker;
-}
-
 
 } // namespace pvfmm
 #endif // STOKESSINGLELAYERKERNEL_HPP

--- a/Lib/include/STKFMM/StokesSingleLayerKernel.hpp
+++ b/Lib/include/STKFMM/StokesSingleLayerKernel.hpp
@@ -1,11 +1,11 @@
 /**
  * @file StokesSingleLayerKernel.hpp
- * @author Wen Yan (wenyan4work@gmail.com)
+ * @author Wen Yan (wenyan4work@gmail.com), Robert Blackwell (rblackwell@flatironinstitute.org)
  * @brief Stokes single layer kernels
- * @version 0.1
- * @date 2019-12-23
+ * @version 0.2
+ * @date 2019-12-23, 2021-10-27
  *
- * @copyright Copyright (c) 2019
+ * @copyright Copyright (c) 2019, 2021
  *
  */
 #ifndef STOKESSINGLELAYER_HPP_
@@ -19,8 +19,12 @@
 
 namespace pvfmm {
 
-
-struct stokes_pvel_new : public GenericKernel<stokes_pvel_new> {
+/*********************************************************
+ *                                                        *
+ *     Stokes P Vel kernel, source: 4, target: 4          *
+ *                                                        *
+ **********************************************************/
+struct stokes_pvel : public GenericKernel<stokes_pvel> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -42,8 +46,12 @@ struct stokes_pvel_new : public GenericKernel<stokes_pvel_new> {
     }
 };
 
-
-struct stokes_pvelgrad_new : public GenericKernel<stokes_pvelgrad_new> {
+/*********************************************************
+ *                                                        *
+ *   Stokes P Vel Grad kernel, source: 4, target: 1+3+3+9 *
+ *                                                        *
+ **********************************************************/
+struct stokes_pvelgrad : public GenericKernel<stokes_pvelgrad> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -78,7 +86,6 @@ struct stokes_pvelgrad_new : public GenericKernel<stokes_pvelgrad_new> {
         u[5] += two * (r2 * fy + nthree * dy * commonCoeff) * rinv5;
         u[6] += two * (r2 * fz + nthree * dz * commonCoeff) * rinv5;
 
-
         // qij = r^2 \delta_{ij} - 3 ri rj, symmetric
         VecType qxx = r2 + nthree * dx * dx;
         VecType qxy = nthree * dx * dy;
@@ -103,8 +110,12 @@ struct stokes_pvelgrad_new : public GenericKernel<stokes_pvelgrad_new> {
     }
 };
 
-
-struct stokes_pvellaplacian_new : public GenericKernel<stokes_pvellaplacian_new> {
+/*********************************************************
+ *                                                        *
+ * Stokes P Vel Laplacian kernel, source: 4, target: 7      *
+ *                                                        *
+ **********************************************************/
+struct stokes_pvellaplacian : public GenericKernel<stokes_pvellaplacian> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -143,9 +154,12 @@ struct stokes_pvellaplacian_new : public GenericKernel<stokes_pvellaplacian_new>
     }
 };
 
-
-
-struct stokes_traction_new : public GenericKernel<stokes_traction_new> {
+/*********************************************************
+ *                                                        *
+ *      Stokes traction kernel, source: 4, target: 9      *
+ *                                                        *
+ **********************************************************/
+struct stokes_traction : public GenericKernel<stokes_traction> {
     static const int FLOPS = 20;
     template <class Real>
     static Real ScaleFactor() {
@@ -179,482 +193,6 @@ struct stokes_traction_new : public GenericKernel<stokes_traction_new> {
         u[8] += dz * dz * commonCoeff + diag;
     }
 };
-
-
-/*********************************************************
- *                                                        *
- *     Stokes P Vel kernel, source: 4, target: 4          *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER = 0>
-void stokes_pvel_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                         Matrix<Real_t> &trg_value) {
-
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facp = set_intrin<Vec_t, Real_t>(2 * FACV);
-    // p = (1/4pi) rk Fk /r^3
-    // const Vec_t n23 = set_intrin<Vec_t, Real_t>(static_cast<Real_t>(-2.0 / 3.0));
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();  // pressure
-            Vec_t vx = zero_intrin<Vec_t>(); // vx
-            Vec_t vy = zero_intrin<Vec_t>(); // vy
-            Vec_t vz = zero_intrin<Vec_t>(); // vz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t tr = bcast_intrin<Vec_t>(&src_value[3][s]); // trace of doublet
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-
-                Vec_t commonCoeff = mul_intrin(fx, dx);
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fy, dy));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fz, dz));
-
-                p = add_intrin(p, mul_intrin(rinv3, commonCoeff));
-                commonCoeff = sub_intrin(commonCoeff, tr);
-                vx = add_intrin(vx, mul_intrin(add_intrin(mul_intrin(r2, fx), mul_intrin(dx, commonCoeff)), rinv3));
-                vy = add_intrin(vy, mul_intrin(add_intrin(mul_intrin(r2, fy), mul_intrin(dy, commonCoeff)), rinv3));
-                vz = add_intrin(vz, mul_intrin(add_intrin(mul_intrin(r2, fz), mul_intrin(dz, commonCoeff)), rinv3));
-            }
-
-            p = add_intrin(mul_intrin(p, facp), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_pvel, stokes_pvel_uKernel, 4, 4)
-
-/*********************************************************
- *                                                        *
- *   Stokes P Vel Grad kernel, source: 4, target: 1+3+3+9 *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_pvelgrad_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                             Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facp = set_intrin<Vec_t, Real_t>(2 * FACV);
-
-    const Real_t FACV5 = 1.0 / (8 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Vec_t facv5 = set_intrin<Vec_t, Real_t>(FACV5);
-    const Vec_t facp5 = set_intrin<Vec_t, Real_t>(2 * FACV5);
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();       // pressure
-            Vec_t vx = zero_intrin<Vec_t>();      // vx
-            Vec_t vy = zero_intrin<Vec_t>();      // vy
-            Vec_t vz = zero_intrin<Vec_t>();      // vz
-            Vec_t pgxSum = zero_intrin<Vec_t>();  // p grad x
-            Vec_t pgySum = zero_intrin<Vec_t>();  // p grad y
-            Vec_t pgzSum = zero_intrin<Vec_t>();  // p grad z
-            Vec_t vxgxSum = zero_intrin<Vec_t>(); // vx grad
-            Vec_t vxgySum = zero_intrin<Vec_t>(); //
-            Vec_t vxgzSum = zero_intrin<Vec_t>(); //
-            Vec_t vygxSum = zero_intrin<Vec_t>(); // vy grad
-            Vec_t vygySum = zero_intrin<Vec_t>(); //
-            Vec_t vygzSum = zero_intrin<Vec_t>(); //
-            Vec_t vzgxSum = zero_intrin<Vec_t>(); // vz grad
-            Vec_t vzgySum = zero_intrin<Vec_t>(); //
-            Vec_t vzgzSum = zero_intrin<Vec_t>(); //
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t tr = bcast_intrin<Vec_t>(&src_value[3][s]); // trace of doublet
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-
-                Vec_t commonCoeff = mul_intrin(fx, dx);
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fy, dy));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fz, dz));
-
-                p = add_intrin(p, mul_intrin(rinv3, commonCoeff));
-                commonCoeff = sub_intrin(commonCoeff, tr);
-                vx = add_intrin(vx, mul_intrin(add_intrin(mul_intrin(r2, fx), mul_intrin(dx, commonCoeff)), rinv3));
-                vy = add_intrin(vy, mul_intrin(add_intrin(mul_intrin(r2, fy), mul_intrin(dy, commonCoeff)), rinv3));
-                vz = add_intrin(vz, mul_intrin(add_intrin(mul_intrin(r2, fz), mul_intrin(dz, commonCoeff)), rinv3));
-                Vec_t px = zero_intrin<Vec_t>(); // p grad x
-                Vec_t py = zero_intrin<Vec_t>(); // p grad y
-                Vec_t pz = zero_intrin<Vec_t>(); // p grad z
-
-                Vec_t vxx = zero_intrin<Vec_t>(); // vx grad
-                Vec_t vxy = zero_intrin<Vec_t>(); //
-                Vec_t vxz = zero_intrin<Vec_t>(); //
-
-                Vec_t vyx = zero_intrin<Vec_t>(); // vy grad
-                Vec_t vyy = zero_intrin<Vec_t>(); //
-                Vec_t vyz = zero_intrin<Vec_t>(); //
-
-                Vec_t vzx = zero_intrin<Vec_t>(); // vz grad
-                Vec_t vzy = zero_intrin<Vec_t>(); //
-                Vec_t vzz = zero_intrin<Vec_t>(); //
-
-                // qij = r^2 \delta_{ij} - 3 ri rj, symmetric
-                Vec_t qxx = add_intrin(r2, mul_intrin(nthree, mul_intrin(dx, dx)));
-                Vec_t qxy = mul_intrin(nthree, mul_intrin(dx, dy));
-                Vec_t qxz = mul_intrin(nthree, mul_intrin(dx, dz));
-                Vec_t qyy = add_intrin(r2, mul_intrin(nthree, mul_intrin(dy, dy)));
-                Vec_t qyz = mul_intrin(nthree, mul_intrin(dy, dz));
-                Vec_t qzz = add_intrin(r2, mul_intrin(nthree, mul_intrin(dz, dz)));
-
-                // px dp/dx, etc
-                commonCoeff = add_intrin(commonCoeff, tr);
-                px = add_intrin(mul_intrin(r2, fx), mul_intrin(mul_intrin(nthree, dx), commonCoeff));
-                py = add_intrin(mul_intrin(r2, fy), mul_intrin(mul_intrin(nthree, dy), commonCoeff));
-                pz = add_intrin(mul_intrin(r2, fz), mul_intrin(mul_intrin(nthree, dz), commonCoeff));
-
-                // vxx = dvx/dx , etc
-                commonCoeff = sub_intrin(commonCoeff, tr);
-                vxx = mul_intrin(qxx, commonCoeff);
-                vxy = add_intrin(mul_intrin(qxy, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dx, fy), mul_intrin(dy, fx))));
-                vxz = add_intrin(mul_intrin(qxz, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dx, fz), mul_intrin(dz, fx))));
-
-                vyx = add_intrin(mul_intrin(qxy, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dy, fx), mul_intrin(dx, fy))));
-                vyy = mul_intrin(qyy, commonCoeff);
-                vyz = add_intrin(mul_intrin(qyz, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dy, fz), mul_intrin(dz, fy))));
-
-                vzx = add_intrin(mul_intrin(qxz, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dz, fx), mul_intrin(dx, fz))));
-                vzy = add_intrin(mul_intrin(qyz, commonCoeff),
-                                 mul_intrin(r2, sub_intrin(mul_intrin(dz, fy), mul_intrin(dy, fz))));
-                vzz = mul_intrin(qzz, commonCoeff);
-
-                // calculate grad
-                pgxSum = add_intrin(pgxSum, mul_intrin(px, rinv5));
-                pgySum = add_intrin(pgySum, mul_intrin(py, rinv5));
-                pgzSum = add_intrin(pgzSum, mul_intrin(pz, rinv5));
-
-                vxgxSum = add_intrin(vxgxSum, mul_intrin(vxx, rinv5));
-                vxgySum = add_intrin(vxgySum, mul_intrin(vxy, rinv5));
-                vxgzSum = add_intrin(vxgzSum, mul_intrin(vxz, rinv5));
-
-                vygxSum = add_intrin(vygxSum, mul_intrin(vyx, rinv5));
-                vygySum = add_intrin(vygySum, mul_intrin(vyy, rinv5));
-                vygzSum = add_intrin(vygzSum, mul_intrin(vyz, rinv5));
-
-                vzgxSum = add_intrin(vzgxSum, mul_intrin(vzx, rinv5));
-                vzgySum = add_intrin(vzgySum, mul_intrin(vzy, rinv5));
-                vzgzSum = add_intrin(vzgzSum, mul_intrin(vzz, rinv5));
-            }
-
-            p = add_intrin(mul_intrin(p, facp), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-
-            pgxSum = add_intrin(mul_intrin(pgxSum, facp5), load_intrin<Vec_t>(&trg_value[4][t]));
-            pgySum = add_intrin(mul_intrin(pgySum, facp5), load_intrin<Vec_t>(&trg_value[5][t]));
-            pgzSum = add_intrin(mul_intrin(pgzSum, facp5), load_intrin<Vec_t>(&trg_value[6][t]));
-
-            vxgxSum = add_intrin(mul_intrin(vxgxSum, facv5), load_intrin<Vec_t>(&trg_value[7][t]));
-            vxgySum = add_intrin(mul_intrin(vxgySum, facv5), load_intrin<Vec_t>(&trg_value[8][t]));
-            vxgzSum = add_intrin(mul_intrin(vxgzSum, facv5), load_intrin<Vec_t>(&trg_value[9][t]));
-
-            vygxSum = add_intrin(mul_intrin(vygxSum, facv5), load_intrin<Vec_t>(&trg_value[10][t]));
-            vygySum = add_intrin(mul_intrin(vygySum, facv5), load_intrin<Vec_t>(&trg_value[11][t]));
-            vygzSum = add_intrin(mul_intrin(vygzSum, facv5), load_intrin<Vec_t>(&trg_value[12][t]));
-
-            vzgxSum = add_intrin(mul_intrin(vzgxSum, facv5), load_intrin<Vec_t>(&trg_value[13][t]));
-            vzgySum = add_intrin(mul_intrin(vzgySum, facv5), load_intrin<Vec_t>(&trg_value[14][t]));
-            vzgzSum = add_intrin(mul_intrin(vzgzSum, facv5), load_intrin<Vec_t>(&trg_value[15][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-            store_intrin(&trg_value[4][t], pgxSum);
-            store_intrin(&trg_value[5][t], pgySum);
-            store_intrin(&trg_value[6][t], pgzSum);
-            store_intrin(&trg_value[7][t], vxgxSum);
-            store_intrin(&trg_value[8][t], vxgySum);
-            store_intrin(&trg_value[9][t], vxgzSum);
-            store_intrin(&trg_value[10][t], vygxSum);
-            store_intrin(&trg_value[11][t], vygySum);
-            store_intrin(&trg_value[12][t], vygzSum);
-            store_intrin(&trg_value[13][t], vzgxSum);
-            store_intrin(&trg_value[14][t], vzgySum);
-            store_intrin(&trg_value[15][t], vzgzSum);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_pvelgrad, stokes_pvelgrad_uKernel, 4, 16)
-
-/*********************************************************
- *                                                        *
- *      Stokes traction kernel, source: 4, target: 9      *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_traction_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                             Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t OOEP = -3.0 / (4 * const_pi<Real_t>());
-    Vec_t inv_nwtn_scal5 = set_intrin<Vec_t, Real_t>(1.0 / (nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal));
-    Vec_t invthree = set_intrin<Vec_t, Real_t>(static_cast<Real_t>(1.0 / 3.0));
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t tv0 = zero_intrin<Vec_t>();
-            Vec_t tv1 = zero_intrin<Vec_t>();
-            Vec_t tv2 = zero_intrin<Vec_t>();
-            Vec_t tv3 = zero_intrin<Vec_t>();
-            Vec_t tv4 = zero_intrin<Vec_t>();
-            Vec_t tv5 = zero_intrin<Vec_t>();
-            Vec_t tv6 = zero_intrin<Vec_t>();
-            Vec_t tv7 = zero_intrin<Vec_t>();
-            Vec_t tv8 = zero_intrin<Vec_t>();
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                Vec_t sv0 = bcast_intrin<Vec_t>(&src_value[0][s]);
-                Vec_t sv1 = bcast_intrin<Vec_t>(&src_value[1][s]);
-                Vec_t sv2 = bcast_intrin<Vec_t>(&src_value[2][s]);
-                Vec_t tr = bcast_intrin<Vec_t>(&src_value[3][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv2 = mul_intrin(rinv, rinv);
-                Vec_t rinv4 = mul_intrin(rinv2, rinv2);
-
-                Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv4), inv_nwtn_scal5);
-
-                Vec_t commonCoeff = mul_intrin(sv0, dx);
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sv1, dy));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(sv2, dz));
-                commonCoeff = sub_intrin(commonCoeff, tr);
-                Vec_t diag = mul_intrin(mul_intrin(mul_intrin(tr, r2), rinv5), invthree);
-
-                tv0 = add_intrin(tv0, mul_intrin(rinv5, mul_intrin(mul_intrin(dx, dx), commonCoeff)));
-                tv0 = add_intrin(tv0, diag);
-                tv1 = add_intrin(tv1, mul_intrin(rinv5, mul_intrin(mul_intrin(dx, dy), commonCoeff)));
-                tv2 = add_intrin(tv2, mul_intrin(rinv5, mul_intrin(mul_intrin(dx, dz), commonCoeff)));
-                tv3 = add_intrin(tv3, mul_intrin(rinv5, mul_intrin(mul_intrin(dy, dx), commonCoeff)));
-                tv4 = add_intrin(tv4, mul_intrin(rinv5, mul_intrin(mul_intrin(dy, dy), commonCoeff)));
-                tv4 = add_intrin(tv4, diag);
-                tv5 = add_intrin(tv5, mul_intrin(rinv5, mul_intrin(mul_intrin(dy, dz), commonCoeff)));
-                tv6 = add_intrin(tv6, mul_intrin(rinv5, mul_intrin(mul_intrin(dz, dx), commonCoeff)));
-                tv7 = add_intrin(tv7, mul_intrin(rinv5, mul_intrin(mul_intrin(dz, dy), commonCoeff)));
-                tv8 = add_intrin(tv8, mul_intrin(rinv5, mul_intrin(mul_intrin(dz, dz), commonCoeff)));
-                tv8 = add_intrin(tv8, diag);
-            }
-            Vec_t ooep = set_intrin<Vec_t, Real_t>(OOEP);
-
-            tv0 = add_intrin(mul_intrin(tv0, ooep), load_intrin<Vec_t>(&trg_value[0][t]));
-            tv1 = add_intrin(mul_intrin(tv1, ooep), load_intrin<Vec_t>(&trg_value[1][t]));
-            tv2 = add_intrin(mul_intrin(tv2, ooep), load_intrin<Vec_t>(&trg_value[2][t]));
-            tv3 = add_intrin(mul_intrin(tv3, ooep), load_intrin<Vec_t>(&trg_value[3][t]));
-            tv4 = add_intrin(mul_intrin(tv4, ooep), load_intrin<Vec_t>(&trg_value[4][t]));
-            tv5 = add_intrin(mul_intrin(tv5, ooep), load_intrin<Vec_t>(&trg_value[5][t]));
-            tv6 = add_intrin(mul_intrin(tv6, ooep), load_intrin<Vec_t>(&trg_value[6][t]));
-            tv7 = add_intrin(mul_intrin(tv7, ooep), load_intrin<Vec_t>(&trg_value[7][t]));
-            tv8 = add_intrin(mul_intrin(tv8, ooep), load_intrin<Vec_t>(&trg_value[8][t]));
-
-            store_intrin(&trg_value[0][t], tv0);
-            store_intrin(&trg_value[1][t], tv1);
-            store_intrin(&trg_value[2][t], tv2);
-            store_intrin(&trg_value[3][t], tv3);
-            store_intrin(&trg_value[4][t], tv4);
-            store_intrin(&trg_value[5][t], tv5);
-            store_intrin(&trg_value[6][t], tv6);
-            store_intrin(&trg_value[7][t], tv7);
-            store_intrin(&trg_value[8][t], tv8);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_traction, stokes_traction_uKernel, 4, 9)
-
-/*********************************************************
- *                                                        *
- * Stokes P Vel Laplacian kernel, source: 4, target: 7      *
- *                                                        *
- **********************************************************/
-template <class Real_t, class Vec_t = Real_t, size_t NWTN_ITER>
-void stokes_pvellaplacian_uKernel(Matrix<Real_t> &src_coord, Matrix<Real_t> &src_value, Matrix<Real_t> &trg_coord,
-                                  Matrix<Real_t> &trg_value) {
-    size_t VecLen = sizeof(Vec_t) / sizeof(Real_t);
-
-    Real_t nwtn_scal = 1; // scaling factor for newton iterations
-    for (int i = 0; i < NWTN_ITER; i++) {
-        nwtn_scal = 2 * nwtn_scal * nwtn_scal * nwtn_scal;
-    }
-    const Real_t FACV = 1.0 / (8 * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Real_t FACLAP = 1.0 / (4 * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * nwtn_scal * const_pi<Real_t>());
-    const Vec_t facv = set_intrin<Vec_t, Real_t>(FACV);
-    const Vec_t facp = set_intrin<Vec_t, Real_t>(2 * FACV);
-    const Vec_t faclap = set_intrin<Vec_t, Real_t>(FACLAP); // laplacian = 1/(4pi) (I/r^3-3rr/r^5)
-    const Vec_t nthree = set_intrin<Vec_t, Real_t>(-3.0);
-
-    size_t src_cnt_ = src_coord.Dim(1);
-    size_t trg_cnt_ = trg_coord.Dim(1);
-
-    for (size_t sblk = 0; sblk < src_cnt_; sblk += SRC_BLK) {
-        size_t src_cnt = src_cnt_ - sblk;
-        if (src_cnt > SRC_BLK)
-            src_cnt = SRC_BLK;
-        for (size_t t = 0; t < trg_cnt_; t += VecLen) {
-            const Vec_t tx = load_intrin<Vec_t>(&trg_coord[0][t]);
-            const Vec_t ty = load_intrin<Vec_t>(&trg_coord[1][t]);
-            const Vec_t tz = load_intrin<Vec_t>(&trg_coord[2][t]);
-
-            Vec_t p = zero_intrin<Vec_t>();     // pressure
-            Vec_t vx = zero_intrin<Vec_t>();    // vx
-            Vec_t vy = zero_intrin<Vec_t>();    // vy
-            Vec_t vz = zero_intrin<Vec_t>();    // vz
-            Vec_t vxlap = zero_intrin<Vec_t>(); // vx laplacian
-            Vec_t vylap = zero_intrin<Vec_t>(); // vy
-            Vec_t vzlap = zero_intrin<Vec_t>(); // vz
-
-            for (size_t s = sblk; s < sblk + src_cnt; s++) {
-                const Vec_t dx = sub_intrin(tx, bcast_intrin<Vec_t>(&src_coord[0][s]));
-                const Vec_t dy = sub_intrin(ty, bcast_intrin<Vec_t>(&src_coord[1][s]));
-                const Vec_t dz = sub_intrin(tz, bcast_intrin<Vec_t>(&src_coord[2][s]));
-
-                const Vec_t fx = bcast_intrin<Vec_t>(&src_value[0][s]);
-                const Vec_t fy = bcast_intrin<Vec_t>(&src_value[1][s]);
-                const Vec_t fz = bcast_intrin<Vec_t>(&src_value[2][s]);
-                const Vec_t tr = bcast_intrin<Vec_t>(&src_value[3][s]);
-
-                Vec_t r2 = mul_intrin(dx, dx);
-                r2 = add_intrin(r2, mul_intrin(dy, dy));
-                r2 = add_intrin(r2, mul_intrin(dz, dz));
-
-                Vec_t rinv = rsqrt_wrapper<Vec_t, Real_t, NWTN_ITER>(r2);
-                Vec_t rinv3 = mul_intrin(mul_intrin(rinv, rinv), rinv);
-                Vec_t rinv5 = mul_intrin(mul_intrin(rinv, rinv), rinv3);
-
-                Vec_t commonCoeff = mul_intrin(fx, dx);
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fy, dy));
-                commonCoeff = add_intrin(commonCoeff, mul_intrin(fz, dz));
-
-                p = add_intrin(p, mul_intrin(rinv3, commonCoeff));
-                commonCoeff = sub_intrin(commonCoeff, tr);
-                vx = add_intrin(vx, mul_intrin(add_intrin(mul_intrin(r2, fx), mul_intrin(dx, commonCoeff)), rinv3));
-                vy = add_intrin(vy, mul_intrin(add_intrin(mul_intrin(r2, fy), mul_intrin(dy, commonCoeff)), rinv3));
-                vz = add_intrin(vz, mul_intrin(add_intrin(mul_intrin(r2, fz), mul_intrin(dz, commonCoeff)), rinv3));
-
-                commonCoeff = add_intrin(commonCoeff, tr);
-                vxlap = add_intrin(vxlap, mul_intrin(mul_intrin(fx, r2), rinv5));
-                vxlap = add_intrin(vxlap, mul_intrin(mul_intrin(mul_intrin(commonCoeff, nthree), rinv5), dx));
-                vylap = add_intrin(vylap, mul_intrin(mul_intrin(fy, r2), rinv5));
-                vylap = add_intrin(vylap, mul_intrin(mul_intrin(mul_intrin(commonCoeff, nthree), rinv5), dy));
-                vzlap = add_intrin(vzlap, mul_intrin(mul_intrin(fz, r2), rinv5));
-                vzlap = add_intrin(vzlap, mul_intrin(mul_intrin(mul_intrin(commonCoeff, nthree), rinv5), dz));
-            }
-
-            p = add_intrin(mul_intrin(p, facp), load_intrin<Vec_t>(&trg_value[0][t]));
-            vx = add_intrin(mul_intrin(vx, facv), load_intrin<Vec_t>(&trg_value[1][t]));
-            vy = add_intrin(mul_intrin(vy, facv), load_intrin<Vec_t>(&trg_value[2][t]));
-            vz = add_intrin(mul_intrin(vz, facv), load_intrin<Vec_t>(&trg_value[3][t]));
-            vxlap = add_intrin(mul_intrin(vxlap, faclap), load_intrin<Vec_t>(&trg_value[4][t]));
-            vylap = add_intrin(mul_intrin(vylap, faclap), load_intrin<Vec_t>(&trg_value[5][t]));
-            vzlap = add_intrin(mul_intrin(vzlap, faclap), load_intrin<Vec_t>(&trg_value[6][t]));
-
-            store_intrin(&trg_value[0][t], p);
-            store_intrin(&trg_value[1][t], vx);
-            store_intrin(&trg_value[2][t], vy);
-            store_intrin(&trg_value[3][t], vz);
-            store_intrin(&trg_value[4][t], vxlap);
-            store_intrin(&trg_value[5][t], vylap);
-            store_intrin(&trg_value[6][t], vzlap);
-        }
-    }
-}
-
-GEN_KERNEL(stokes_pvellaplacian, stokes_pvellaplacian_uKernel, 4, 7)
 
 } // namespace pvfmm
 #endif // STOKESSINGLELAYERKERNEL_HPP

--- a/Lib/include/STKFMM/stkfmm_helpers.hpp
+++ b/Lib/include/STKFMM/stkfmm_helpers.hpp
@@ -6,70 +6,8 @@
 // clang-format off
 // do not format macro
 
-#if defined __MIC__
-#define Vec_ts Real_t
-#define Vec_td Real_t
-#elif defined __AVX__
-#define Vec_ts __m256
-#define Vec_td __m256d
-#elif defined __SSE3__
-#define Vec_ts __m128
-#define Vec_td __m128d
-#else
-#define Vec_ts Real_t
-#define Vec_td Real_t
-#endif
-
-#define GEN_KERNEL_HELPER(MICROKERNEL, SRCDIM, TARDIM, VEC_T, REAL_T)                                                  \
-    generic_kernel<REAL_T, SRCDIM, TARDIM, MICROKERNEL<REAL_T, VEC_T, newton_iter>>(                                   \
-        (REAL_T *)r_src, src_cnt, (REAL_T *)v_src, dof, (REAL_T *)r_trg, trg_cnt, (REAL_T *)v_trg, mem_mgr)
-
-#define GEN_KERNEL(KERNEL, MICROKERNEL, SRCDIM, TARDIM)                                                                \
-    template <class T, int newton_iter = 0>                                                                            \
-    void KERNEL(T *r_src, int src_cnt, T *v_src, int dof, T *r_trg, int trg_cnt, T *v_trg,                             \
-                mem::MemoryManager *mem_mgr) {                                                                         \
-                                                                                                                       \
-        if (mem::TypeTraits<T>::ID() == mem::TypeTraits<float>::ID()) {                                                \
-            typedef float Real_t;                                                                                      \
-            GEN_KERNEL_HELPER(MICROKERNEL, SRCDIM, TARDIM, Vec_ts, Real_t);                                            \
-        } else if (mem::TypeTraits<T>::ID() == mem::TypeTraits<double>::ID()) {                                        \
-            typedef double Real_t;                                                                                     \
-            GEN_KERNEL_HELPER(MICROKERNEL, SRCDIM, TARDIM, Vec_td, Real_t);                                            \
-        } else {                                                                                                       \
-            typedef T Real_t;                                                                                          \
-            GEN_KERNEL_HELPER(MICROKERNEL, SRCDIM, TARDIM, Real_t, Real_t);                                            \
-        }                                                                                                              \
-    }
-// clang-format on
-
 namespace pvfmm {
 constexpr int SRC_BLK = 500;
-
-/**
- * @brief inverse square root of a simd vec type
- *
- * @tparam Vec_t
- * @tparam Real_t
- * @tparam nwtn number of newton iterations
- * @param r2
- * @return Vec_t
- */
-template <typename Vec_t, typename Real_t, int nwtn>
-inline Vec_t rsqrt_wrapper(Vec_t r2) {
-    switch (nwtn) {
-    case 0:
-        return pvfmm::rsqrt_intrin0<Vec_t, Real_t>(r2);
-    case 1:
-        return pvfmm::rsqrt_intrin1<Vec_t, Real_t>(r2);
-    case 2:
-        return pvfmm::rsqrt_intrin2<Vec_t, Real_t>(r2);
-    case 3:
-        return pvfmm::rsqrt_intrin3<Vec_t, Real_t>(r2);
-    default:
-        break;
-    }
-}
-
 } // namespace pvfmm
 
 namespace stkfmm {


### PR DESCRIPTION
This commit adds SCTL as a submodule, changed the implementations of all microkernels to use the new `pvfmm::GenericKernel` interface, and moves more generally to work with the current `develop` branch of pvfmm (currently https://github.com/dmalhotra/pvfmm/commit/576b42f9ad1706182f27f5e4162fb1fc438e3706).

I think further verification is needed before merging. All kernels pass muster to my knowledge, but a full analysis is probably necessary as all target results change due to various changes in both the `sqrt` implementation and some orders of operation in the kernels themselves.